### PR TITLE
Term codes

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,3 +17,37 @@ jobs:
       run: make
     - name: test
       run: ./test_unishox2 -t
+    - name: test preset 0
+      run: ./test_unishox2 -t 0
+    - name: test preset 1
+      run: ./test_unishox2 -t 1
+    - name: test preset 2
+      run: ./test_unishox2 -t 2
+    - name: test preset 3
+      run: ./test_unishox2 -t 3
+    - name: test preset 4
+      run: ./test_unishox2 -t 4
+    - name: test preset 5
+      run: ./test_unishox2 -t 5
+    - name: test preset 6
+      run: ./test_unishox2 -t 6
+    - name: test preset 7
+      run: ./test_unishox2 -t 7
+    - name: test preset 8
+      run: ./test_unishox2 -t 8
+    - name: test preset 9
+      run: ./test_unishox2 -t 9
+    - name: test preset 10
+      run: ./test_unishox2 -t 10
+    - name: test preset 11
+      run: ./test_unishox2 -t 11
+    - name: test preset 12
+      run: ./test_unishox2 -t 12
+    - name: test preset 13
+      run: ./test_unishox2 -t 13
+    - name: test preset 14
+      run: ./test_unishox2 -t 14
+    - name: test preset 15
+      run: ./test_unishox2 -t 15
+    - name: test preset 16
+      run: ./test_unishox2 -t 16

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,38 +16,38 @@ jobs:
     - name: make
       run: make
     - name: test
-      run: ./test_unishox2 -t
+      run: ./test_unishox2 -t && ./test_unishox2-w-olen -t
     - name: test preset 0
-      run: ./test_unishox2 -t 0
+      run: ./test_unishox2 -t 0 && ./test_unishox2-w-olen -t 0
     - name: test preset 1
-      run: ./test_unishox2 -t 1
+      run: ./test_unishox2 -t 1 && ./test_unishox2-w-olen -t 1
     - name: test preset 2
-      run: ./test_unishox2 -t 2
+      run: ./test_unishox2 -t 2 && ./test_unishox2-w-olen -t 2
     - name: test preset 3
-      run: ./test_unishox2 -t 3
+      run: ./test_unishox2 -t 3 && ./test_unishox2-w-olen -t 3
     - name: test preset 4
-      run: ./test_unishox2 -t 4
+      run: ./test_unishox2 -t 4 && ./test_unishox2-w-olen -t 4
     - name: test preset 5
-      run: ./test_unishox2 -t 5
+      run: ./test_unishox2 -t 5 && ./test_unishox2-w-olen -t 5
     - name: test preset 6
-      run: ./test_unishox2 -t 6
+      run: ./test_unishox2 -t 6 && ./test_unishox2-w-olen -t 6
     - name: test preset 7
-      run: ./test_unishox2 -t 7
+      run: ./test_unishox2 -t 7 && ./test_unishox2-w-olen -t 7
     - name: test preset 8
-      run: ./test_unishox2 -t 8
+      run: ./test_unishox2 -t 8 && ./test_unishox2-w-olen -t 8
     - name: test preset 9
-      run: ./test_unishox2 -t 9
+      run: ./test_unishox2 -t 9 && ./test_unishox2-w-olen -t 9
     - name: test preset 10
-      run: ./test_unishox2 -t 10
+      run: ./test_unishox2 -t 10 && ./test_unishox2-w-olen -t 10
     - name: test preset 11
-      run: ./test_unishox2 -t 11
+      run: ./test_unishox2 -t 11 && ./test_unishox2-w-olen -t 11
     - name: test preset 12
-      run: ./test_unishox2 -t 12
+      run: ./test_unishox2 -t 12 && ./test_unishox2-w-olen -t 12
     - name: test preset 13
-      run: ./test_unishox2 -t 13
+      run: ./test_unishox2 -t 13 && ./test_unishox2-w-olen -t 13
     - name: test preset 14
-      run: ./test_unishox2 -t 14
+      run: ./test_unishox2 -t 14 && ./test_unishox2-w-olen -t 14
     - name: test preset 15
-      run: ./test_unishox2 -t 15
+      run: ./test_unishox2 -t 15 && ./test_unishox2-w-olen -t 15
     - name: test preset 16
-      run: ./test_unishox2 -t 16
+      run: ./test_unishox2 -t 16 && ./test_unishox2-w-olen -t 16

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ SRCFILE1 = test_unishox2.c
 OUTFILE = test_unishox2
 
 default:
-	gcc -o $(OUTFILE) $(SRCFILE) $(SRCFILE1)
+	gcc $(CFLAGS) -o $(OUTFILE) $(SRCFILE) $(SRCFILE1)
+	gcc $(CFLAGS) -DUNISHOX_API_WITH_OUTPUT_LEN=1 -o $(OUTFILE)-w-olen $(SRCFILE) $(SRCFILE1)
 
 install: default
 	cp $(OUTFILE) /usr/bin/

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Unishox supports the entire Unicode character set.  As of now it supports UTF-8 
 - Thanks to [Chris Partridge](https://github.com/tweedge) for his [port of Unishox2 to CPython](https://github.com/tweedge/unishox2-py3) and his [comprehensive tests](https://github.com/tweedge/unishox2-py3#integration-tests) using [Hypothesis](https://hypothesis.readthedocs.io/en/latest) and [extensive performance tests](https://github.com/tweedge/unishox2-py3#performance).
 - Thanks to [Stephan Hadinger](https://github.com/s-hadinger) for his [port of Unishox1 to Python for Tasmota](https://github.com/arendst/Tasmota/tree/development/tools/unishox)
 - Thanks to [Luis Díaz Más](https://github.com/piponazo) for his PRs to support MSVC and CMake setup
+- Thanks to [James Z.M. Gao](https://github.com/gsm55) for his PRs on improving presets, unit tests, bug fixes and more.
 
 # Issues
 

--- a/test_unishox2.c
+++ b/test_unishox2.c
@@ -101,6 +101,10 @@ int test_ushx_cd(char *input, int preset) {
   char dbuf[251];
   int len = (int)strlen(input);
   int clen = unishox2_compress_preset_lines(input, len, cbuf, preset, NULL);
+  if (clen > (int)sizeof cbuf) {
+    printf("Compress Overflow\n");
+    return 0;
+  }
   printf("\n\n");
   int dlen = unishox2_decompress_preset_lines(cbuf, clen, dbuf, preset, NULL);
   if (dlen > (int)sizeof dbuf) {
@@ -109,6 +113,7 @@ int test_ushx_cd(char *input, int preset) {
   } else if (dlen < (int)sizeof dbuf)
     dbuf[dlen] = '\0';
   if (dlen != len) {
+    dbuf[sizeof dbuf - 1] = '\0';
     printf("Fail len: %d, %d:\n%s\n%s\n", len, dlen, input, dbuf);
     return 0;
   }

--- a/test_unishox2.c
+++ b/test_unishox2.c
@@ -202,6 +202,21 @@ double timedifference(uint32_t t0, uint32_t t1) {
     return ret;
 }
 
+int presetForUnicode(int preset) {
+  switch (preset) {
+  case  1: return 0; // false
+  case  2: return 0; // false
+  case  3: return 0; // false
+  case  4: return 0; // false
+  case 10: return 0; // false
+  case 11: return 0; // false
+  case 14: return 0; // false
+  default: break;
+  }
+
+  return  1; // true
+}
+
 int main(int argv, char *args[]) {
 
 char cbuf[4096];
@@ -225,7 +240,7 @@ if (argv >= 4 && strcmp(args[1], "-c") == 0) {
       perror(args[2]);
       return 1;
    }
-   wfp = fopen(args[3], "wb+");
+   wfp = fopen(args[3], "wb");
    if (wfp == NULL) {
       perror(args[3]);
       return 1;
@@ -261,7 +276,7 @@ if (argv >= 4 && strcmp(args[1], "-d") == 0) {
       perror(args[2]);
       return 1;
    }
-   wfp = fopen(args[3], "wb+");
+   wfp = fopen(args[3], "wb");
    if (wfp == NULL) {
       perror(args[3]);
       return 1;
@@ -295,7 +310,7 @@ if (argv >= 4 && (strcmp(args[1], "-g") == 0 ||
       return 1;
    }
    sprintf(cbuf, "%s.h", args[3]);
-   wfp = fopen(cbuf, "w+");
+   wfp = fopen(cbuf, "w");
    if (wfp == NULL) {
       perror(args[3]);
       return 1;
@@ -395,6 +410,11 @@ if (argv >= 2 && strcmp(args[1], "-t") == 0) {
    if (argv > 2)
      preset = atoi(args[2]);
 
+   if (preset < 0 || 16 < preset) {
+     printf("invalid preset %d\n", preset);
+     return 1;
+   }
+
    // check template
    {
      char cbuf[128];
@@ -421,228 +441,228 @@ if (argv >= 2 && strcmp(args[1], "-t") == 0) {
     if (!test_ushx_cd("HELLO WORLD HELLO WORLD", preset)) return 1;
 
     // Numbers
-    if (!test_ushx_cd("Hello1", preset)) return 1;
-    if (!test_ushx_cd("Hello1 World2", preset)) return 1;
-    if (!test_ushx_cd("Hello123", preset)) return 1;
-    if (!test_ushx_cd("12345678", preset)) return 1;
-    if (!test_ushx_cd("12345678 12345678", preset)) return 1;
-    if (!test_ushx_cd("HELLO WORLD 1234 hello world12", preset)) return 1;
-    if (!test_ushx_cd("HELLO 234 WORLD", preset)) return 1;
-    if (!test_ushx_cd("9 HELLO, WORLD", preset)) return 1;
-    if (!test_ushx_cd("H1e2l3l4o5 w6O7R8L9D", preset)) return 1;
-    if (!test_ushx_cd("8+80=88", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Hello1", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Hello1 World2", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Hello123", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("12345678", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("12345678 12345678", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("HELLO WORLD 1234 hello world12", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("HELLO 234 WORLD", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("9 HELLO, WORLD", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("H1e2l3l4o5 w6O7R8L9D", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("8+80=88", preset)) return 1;
 
     // Symbols
-    if (!test_ushx_cd("~!@#$%^&*()_+=-`;'\\|\":,./?><", preset)) return 1;
-    if (!test_ushx_cd("if (!test_ushx_cd(\"H1e2l3l4o5 w6O7R8L9D\", preset)) return 1;", preset)) return 1;
-    if (!test_ushx_cd("Hello\tWorld\tHow\tare\tyou?", preset)) return 1;
-    if (!test_ushx_cd("Hello~World~How~are~you?", preset)) return 1;
-    if (!test_ushx_cd("Hello\rWorld\rHow\rare\ryou?", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("~!@#$%^&*()_+=-`;'\\|\":,./?><", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("if (!test_ushx_cd(\"H1e2l3l4o5 w6O7R8L9D\", preset)) return 1;", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("Hello\tWorld\tHow\tare\tyou?", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("Hello~World~How~are~you?", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("Hello\rWorld\rHow\rare\ryou?", preset)) return 1;
 
     // Repeat
-    if (!test_ushx_cd("-----------------///////////////", preset)) return 1;
-    if (!test_ushx_cd("-----------------Hello World1111111111112222222abcdef12345abcde1234_////////Hello World///////", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("-----------------///////////////", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("-----------------Hello World1111111111112222222abcdef12345abcde1234_////////Hello World///////", preset)) return 1;
 
     // Nibbles
-    if (!test_ushx_cd("fa01b51e-7ecc-4e3e-be7b-918a4c2c891c", preset)) return 1;
-    if (!test_ushx_cd("Fa01b51e-7ecc-4e3e-be7b-918a4c2c891c", preset)) return 1;
-    if (!test_ushx_cd("fa01b51e-7ecc-4e3e-be7b-9182c891c", preset)) return 1;
-    if (!test_ushx_cd("760FBCA3-272E-4F1A-BF88-8472DF6BD994", preset)) return 1;
-    if (!test_ushx_cd("760FBCA3-272E-4F1A-BF88-8472DF6Bd994", preset)) return 1;
-    if (!test_ushx_cd("760FBCA3-272E-4F1A-BF88-8472DF6Bg994", preset)) return 1;
-    if (!test_ushx_cd("FBCA3-272E-4F1A-BF88-8472DF6BD994", preset)) return 1;
-    if (!test_ushx_cd("Hello 1 5347a688-d8bf-445d-86d1-b470f95b007fHello World", preset)) return 1;
-    if (!test_ushx_cd("01234567890123", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("fa01b51e-7ecc-4e3e-be7b-918a4c2c891c", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Fa01b51e-7ecc-4e3e-be7b-918a4c2c891c", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("fa01b51e-7ecc-4e3e-be7b-9182c891c", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("760FBCA3-272E-4F1A-BF88-8472DF6BD994", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("760FBCA3-272E-4F1A-BF88-8472DF6Bd994", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("760FBCA3-272E-4F1A-BF88-8472DF6Bg994", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("FBCA3-272E-4F1A-BF88-8472DF6BD994", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Hello 1 5347a688-d8bf-445d-86d1-b470f95b007fHello World", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("01234567890123", preset)) return 1;
 
     // Templates
-    if (!test_ushx_cd("2020-12-31", preset)) return 1;
-    if (!test_ushx_cd("1934-02", preset)) return 1;
-    if (!test_ushx_cd("2020-12-31T12:23:59.234Z", preset)) return 1;
-    if (!test_ushx_cd("1899-05-12T23:59:59.23434", preset)) return 1;
-    if (!test_ushx_cd("1899-05-12T23:59:59", preset)) return 1;
-    if (!test_ushx_cd("2020-12-31T12:23:59.234Zfa01b51e-7ecc-4e3e-be7b-918a4c2c891c", preset)) return 1;
-    if (!test_ushx_cd("顔に(993) 345-3495あり", preset)) return 1;
-    if (!test_ushx_cd("HELLO(993) 345-3495WORLD", preset)) return 1;
-    if (!test_ushx_cd("顔に1899-05-12T23:59:59あり", preset)) return 1;
-    if (!test_ushx_cd("HELLO1899-05-12T23:59:59WORLD", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("2020-12-31", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("1934-02", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("2020-12-31T12:23:59.234Z", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("1899-05-12T23:59:59.23434", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("1899-05-12T23:59:59", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("2020-12-31T12:23:59.234Zfa01b51e-7ecc-4e3e-be7b-918a4c2c891c", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("顔に(993) 345-3495あり", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("HELLO(993) 345-3495WORLD", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("顔に1899-05-12T23:59:59あり", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("HELLO1899-05-12T23:59:59WORLD", preset)) return 1;
 
-    if (!test_ushx_cd("Cada buhonero alaba sus agujas. - A peddler praises his needles (wares).", preset)) return 1;
-    if (!test_ushx_cd("Cada gallo canta en su muladar. - Each rooster sings on its dung-heap.", preset)) return 1;
-    if (!test_ushx_cd("Cada martes tiene su domingo. - Each Tuesday has its Sunday.", preset)) return 1;
-    if (!test_ushx_cd("Cada uno habla de la feria como le va en ella. - Our way of talking about things reflects our relevant experience, good or bad.", preset)) return 1;
-    if (!test_ushx_cd("Dime con quien andas y te diré quién eres.. - Tell me who you walk with, and I will tell you who you are.", preset)) return 1;
-    if (!test_ushx_cd("Donde comen dos, comen tres. - You can add one person more in any situation you are managing.", preset)) return 1;
-    if (!test_ushx_cd("El amor es ciego. - Love is blind", preset)) return 1;
-    if (!test_ushx_cd("El amor todo lo iguala. - Love smoothes life out.", preset)) return 1;
-    if (!test_ushx_cd("El tiempo todo lo cura. - Time cures all.", preset)) return 1;
-    if (!test_ushx_cd("La avaricia rompe el saco. - Greed bursts the sack.", preset)) return 1;
-    if (!test_ushx_cd("La cara es el espejo del alma. - The face is the mirror of the soul.", preset)) return 1;
-    if (!test_ushx_cd("La diligencia es la madre de la buena ventura. - Diligence is the mother of good fortune.", preset)) return 1;
-    if (!test_ushx_cd("La fe mueve montañas. - Faith moves mountains.", preset)) return 1;
-    if (!test_ushx_cd("La mejor palabra siempre es la que queda por decir. - The best word is the one left unsaid.", preset)) return 1;
-    if (!test_ushx_cd("La peor gallina es la que más cacarea. - The worst hen is the one that clucks the most.", preset)) return 1;
-    if (!test_ushx_cd("La sangre sin fuego hierve. - Blood boils without fire.", preset)) return 1;
-    if (!test_ushx_cd("La vida no es un camino de rosas. - Life is not a path of roses.", preset)) return 1;
-    if (!test_ushx_cd("Las burlas se vuelven veras. - Bad jokes become reality.", preset)) return 1;
-    if (!test_ushx_cd("Las desgracias nunca vienen solas. - Misfortunes never come one at a time.", preset)) return 1;
-    if (!test_ushx_cd("Lo comido es lo seguro. - You can only be really certain of what is already in your belly.", preset)) return 1;
-    if (!test_ushx_cd("Los años no pasan en balde. - Years don't pass in vain.", preset)) return 1;
-    if (!test_ushx_cd("Los celos son malos consejeros. - Jealousy is a bad counsellor.", preset)) return 1;
-    if (!test_ushx_cd("Los tiempos cambian. - Times change.", preset)) return 1;
-    if (!test_ushx_cd("Mañana será otro día. - Tomorrow will be another day.", preset)) return 1;
-    if (!test_ushx_cd("Ningún jorobado ve su joroba. - No hunchback sees his own hump.", preset)) return 1;
-    if (!test_ushx_cd("No cantan dos gallos en un gallinero. - Two roosters do not crow in a henhouse.", preset)) return 1;
-    if (!test_ushx_cd("No hay harina sin salvado. - No flour without bran.", preset)) return 1;
-    if (!test_ushx_cd("No por mucho madrugar, amanece más temprano.. - No matter if you rise early because it does not sunrise earlier.", preset)) return 1;
-    if (!test_ushx_cd("No se puede hacer tortilla sin romper los huevos. - One can't make an omelette without breaking eggs.", preset)) return 1;
-    if (!test_ushx_cd("No todas las verdades son para dichas. - Not every truth should be said.", preset)) return 1;
-    if (!test_ushx_cd("No todo el monte es orégano. - The whole hillside is not covered in spice.", preset)) return 1;
-    if (!test_ushx_cd("Nunca llueve a gusto de todos. - It never rains to everyone's taste.", preset)) return 1;
-    if (!test_ushx_cd("Perro ladrador, poco mordedor.. - A dog that barks often seldom bites.", preset)) return 1;
-    if (!test_ushx_cd("Todos los caminos llevan a Roma. - All roads lead to Rome.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Cada buhonero alaba sus agujas. - A peddler praises his needles (wares).", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Cada gallo canta en su muladar. - Each rooster sings on its dung-heap.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Cada martes tiene su domingo. - Each Tuesday has its Sunday.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Cada uno habla de la feria como le va en ella. - Our way of talking about things reflects our relevant experience, good or bad.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Dime con quien andas y te diré quién eres.. - Tell me who you walk with, and I will tell you who you are.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Donde comen dos, comen tres. - You can add one person more in any situation you are managing.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("El amor es ciego. - Love is blind", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("El amor todo lo iguala. - Love smoothes life out.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("El tiempo todo lo cura. - Time cures all.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("La avaricia rompe el saco. - Greed bursts the sack.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("La cara es el espejo del alma. - The face is the mirror of the soul.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("La diligencia es la madre de la buena ventura. - Diligence is the mother of good fortune.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("La fe mueve montañas. - Faith moves mountains.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("La mejor palabra siempre es la que queda por decir. - The best word is the one left unsaid.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("La peor gallina es la que más cacarea. - The worst hen is the one that clucks the most.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("La sangre sin fuego hierve. - Blood boils without fire.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("La vida no es un camino de rosas. - Life is not a path of roses.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Las burlas se vuelven veras. - Bad jokes become reality.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Las desgracias nunca vienen solas. - Misfortunes never come one at a time.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Lo comido es lo seguro. - You can only be really certain of what is already in your belly.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Los años no pasan en balde. - Years don't pass in vain.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Los celos son malos consejeros. - Jealousy is a bad counsellor.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Los tiempos cambian. - Times change.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Mañana será otro día. - Tomorrow will be another day.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Ningún jorobado ve su joroba. - No hunchback sees his own hump.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("No cantan dos gallos en un gallinero. - Two roosters do not crow in a henhouse.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("No hay harina sin salvado. - No flour without bran.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("No por mucho madrugar, amanece más temprano.. - No matter if you rise early because it does not sunrise earlier.", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("No se puede hacer tortilla sin romper los huevos. - One can't make an omelette without breaking eggs.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("No todas las verdades son para dichas. - Not every truth should be said.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("No todo el monte es orégano. - The whole hillside is not covered in spice.", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("Nunca llueve a gusto de todos. - It never rains to everyone's taste.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Perro ladrador, poco mordedor.. - A dog that barks often seldom bites.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Todos los caminos llevan a Roma. - All roads lead to Rome.", preset)) return 1;
 
     // Unicode
-    if (!test_ushx_cd("案ずるより産むが易し。 - Giving birth to a baby is easier than worrying about it.", preset)) return 1;
-    if (!test_ushx_cd("出る杭は打たれる。 - The stake that sticks up gets hammered down.", preset)) return 1;
-    if (!test_ushx_cd("知らぬが仏。 - Not knowing is Buddha. - Ignorance is bliss.", preset)) return 1;
-    if (!test_ushx_cd("見ぬが花。 - Not seeing is a flower. - Reality can't compete with imagination.", preset)) return 1;
-    if (!test_ushx_cd("花は桜木人は武士 - Of flowers, the cherry blossom; of men, the warrior.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("案ずるより産むが易し。 - Giving birth to a baby is easier than worrying about it.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("出る杭は打たれる。 - The stake that sticks up gets hammered down.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("知らぬが仏。 - Not knowing is Buddha. - Ignorance is bliss.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("見ぬが花。 - Not seeing is a flower. - Reality can't compete with imagination.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("花は桜木人は武士 - Of flowers, the cherry blossom; of men, the warrior.", preset)) return 1;
 
-    if (!test_ushx_cd("小洞不补，大洞吃苦 - A small hole not mended in time will become a big hole much more difficult to mend.", preset)) return 1;
-    if (!test_ushx_cd("读万卷书不如行万里路 - Reading thousands of books is not as good as traveling thousands of miles", preset)) return 1;
-    if (!test_ushx_cd("福无重至,祸不单行 - Fortune does not come twice. Misfortune does not come alone.", preset)) return 1;
-    if (!test_ushx_cd("风向转变时,有人筑墙,有人造风车 - When the wind changes, some people build walls and have artificial windmills.", preset)) return 1;
-    if (!test_ushx_cd("父债子还 - Father's debt, son to give back.", preset)) return 1;
-    if (!test_ushx_cd("害人之心不可有 - Do not harbour intentions to hurt others.", preset)) return 1;
-    if (!test_ushx_cd("今日事，今日毕 - Things of today, accomplished today.", preset)) return 1;
-    if (!test_ushx_cd("空穴来风,未必无因 - Where there's smoke, there's fire.", preset)) return 1;
-    if (!test_ushx_cd("良药苦口 - Good medicine tastes bitter.", preset)) return 1;
-    if (!test_ushx_cd("人算不如天算 - Man proposes and God disposes", preset)) return 1;
-    if (!test_ushx_cd("师傅领进门，修行在个人 - Teachers open the door. You enter by yourself.", preset)) return 1;
-    if (!test_ushx_cd("授人以鱼不如授之以渔 - Teach a man to take a fish is not equal to teach a man how to fish.", preset)) return 1;
-    if (!test_ushx_cd("树倒猢狲散 - When the tree falls, the monkeys scatter.", preset)) return 1;
-    if (!test_ushx_cd("水能载舟，亦能覆舟 - Not only can water float a boat, it can sink it also.", preset)) return 1;
-    if (!test_ushx_cd("朝被蛇咬，十年怕井绳 - Once bitten by a snake for a snap dreads a rope for a decade.", preset)) return 1;
-    if (!test_ushx_cd("一分耕耘，一分收获 - If one does not plow, there will be no harvest.", preset)) return 1;
-    if (!test_ushx_cd("有钱能使鬼推磨 - If you have money you can make the devil push your grind stone.", preset)) return 1;
-    if (!test_ushx_cd("一失足成千古恨，再回头已百年身 - A single slip may cause lasting sorrow.", preset)) return 1;
-    if (!test_ushx_cd("自助者天助 - Those who help themselves, God will help.", preset)) return 1;
-    if (!test_ushx_cd("早起的鸟儿有虫吃 - Early bird gets the worm.", preset)) return 1;
-    if (!test_ushx_cd("This is first line,\r\nThis is second line", preset)) return 1;
-    if (!test_ushx_cd("{\"menu\": {\n  \"id\": \"file\",\n  \"value\": \"File\",\n  \"popup\": {\n    \"menuitem\": [\n      {\"value\": \"New\", \"onclick\": \"CreateNewDoc()\"},\n      {\"value\": \"Open\", \"onclick\": \"OpenDoc()\"},\n      {\"value\": \"Close\", \"onclick\": \"CloseDoc()\"}\n    ]\n  }\n}}", preset)) return 1;
-    if (!test_ushx_cd("{\"menu\": {\r\n  \"id\": \"file\",\r\n  \"value\": \"File\",\r\n  \"popup\": {\r\n    \"menuitem\": [\r\n      {\"value\": \"New\", \"onclick\": \"CreateNewDoc()\"},\r\n      {\"value\": \"Open\", \"onclick\": \"OpenDoc()\"},\r\n      {\"value\":\"Close\", \"onclick\": \"CloseDoc()\"}\r\n    ]\r\n  }\r\n}}", preset)) return 1;
-    if (!test_ushx_cd("https://siara.cc", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("小洞不补，大洞吃苦 - A small hole not mended in time will become a big hole much more difficult to mend.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("读万卷书不如行万里路 - Reading thousands of books is not as good as traveling thousands of miles", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("福无重至,祸不单行 - Fortune does not come twice. Misfortune does not come alone.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("风向转变时,有人筑墙,有人造风车 - When the wind changes, some people build walls and have artificial windmills.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("父债子还 - Father's debt, son to give back.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("害人之心不可有 - Do not harbour intentions to hurt others.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("今日事，今日毕 - Things of today, accomplished today.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("空穴来风,未必无因 - Where there's smoke, there's fire.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("良药苦口 - Good medicine tastes bitter.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("人算不如天算 - Man proposes and God disposes", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("师傅领进门，修行在个人 - Teachers open the door. You enter by yourself.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("授人以鱼不如授之以渔 - Teach a man to take a fish is not equal to teach a man how to fish.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("树倒猢狲散 - When the tree falls, the monkeys scatter.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("水能载舟，亦能覆舟 - Not only can water float a boat, it can sink it also.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("朝被蛇咬，十年怕井绳 - Once bitten by a snake for a snap dreads a rope for a decade.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("一分耕耘，一分收获 - If one does not plow, there will be no harvest.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("有钱能使鬼推磨 - If you have money you can make the devil push your grind stone.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("一失足成千古恨，再回头已百年身 - A single slip may cause lasting sorrow.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("自助者天助 - Those who help themselves, God will help.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("早起的鸟儿有虫吃 - Early bird gets the worm.", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("This is first line,\r\nThis is second line", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("{\"menu\": {\n  \"id\": \"file\",\n  \"value\": \"File\",\n  \"popup\": {\n    \"menuitem\": [\n      {\"value\": \"New\", \"onclick\": \"CreateNewDoc()\"},\n      {\"value\": \"Open\", \"onclick\": \"OpenDoc()\"},\n      {\"value\": \"Close\", \"onclick\": \"CloseDoc()\"}\n    ]\n  }\n}}", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("{\"menu\": {\r\n  \"id\": \"file\",\r\n  \"value\": \"File\",\r\n  \"popup\": {\r\n    \"menuitem\": [\r\n      {\"value\": \"New\", \"onclick\": \"CreateNewDoc()\"},\r\n      {\"value\": \"Open\", \"onclick\": \"OpenDoc()\"},\r\n      {\"value\":\"Close\", \"onclick\": \"CloseDoc()\"}\r\n    ]\r\n  }\r\n}}", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("https://siara.cc", preset)) return 1;
 
-    if (!test_ushx_cd("符号\"δ\"表", preset)) return 1;
-    if (!test_ushx_cd("学者地”[3]。学者", preset)) return 1;
-    if (!test_ushx_cd("한데......아무", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("符号\"δ\"表", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("学者地”[3]。学者", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("한데......아무", preset)) return 1;
 
     // English
-    if (!test_ushx_cd("Beauty is not in the face. Beauty is a light in the heart.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Beauty is not in the face. Beauty is a light in the heart.", preset)) return 1;
     // Spanish
-    if (!test_ushx_cd("La belleza no está en la cara. La belleza es una luz en el corazón.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("La belleza no está en la cara. La belleza es una luz en el corazón.", preset)) return 1;
     // French
-    if (!test_ushx_cd("La beauté est pas dans le visage. La beauté est la lumière dans le coeur.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("La beauté est pas dans le visage. La beauté est la lumière dans le coeur.", preset)) return 1;
     // Portugese
-    if (!test_ushx_cd("A beleza não está na cara. A beleza é a luz no coração.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("A beleza não está na cara. A beleza é a luz no coração.", preset)) return 1;
     // Dutch
-    if (!test_ushx_cd("Schoonheid is niet in het gezicht. Schoonheid is een licht in het hart.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Schoonheid is niet in het gezicht. Schoonheid is een licht in het hart.", preset)) return 1;
 
     // German
-    if (!test_ushx_cd("Schönheit ist nicht im Gesicht. Schönheit ist ein Licht im Herzen.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Schönheit ist nicht im Gesicht. Schönheit ist ein Licht im Herzen.", preset)) return 1;
     // Spanish
-    if (!test_ushx_cd("La belleza no está en la cara. La belleza es una luz en el corazón.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("La belleza no está en la cara. La belleza es una luz en el corazón.", preset)) return 1;
     // French
-    if (!test_ushx_cd("La beauté est pas dans le visage. La beauté est la lumière dans le coeur.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("La beauté est pas dans le visage. La beauté est la lumière dans le coeur.", preset)) return 1;
     // Italian
-    if (!test_ushx_cd("La bellezza non è in faccia. La bellezza è la luce nel cuore.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("La bellezza non è in faccia. La bellezza è la luce nel cuore.", preset)) return 1;
     // Swedish
-    if (!test_ushx_cd("Skönhet är inte i ansiktet. Skönhet är ett ljus i hjärtat.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Skönhet är inte i ansiktet. Skönhet är ett ljus i hjärtat.", preset)) return 1;
     // Romanian
-    if (!test_ushx_cd("Frumusețea nu este în față. Frumusețea este o lumină în inimă.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Frumusețea nu este în față. Frumusețea este o lumină în inimă.", preset)) return 1;
     // Ukranian
-    if (!test_ushx_cd("Краса не в особі. Краса - це світло в серці.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Краса не в особі. Краса - це світло в серці.", preset)) return 1;
     // Greek
-    if (!test_ushx_cd("Η ομορφιά δεν είναι στο πρόσωπο. Η ομορφιά είναι ένα φως στην καρδιά.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Η ομορφιά δεν είναι στο πρόσωπο. Η ομορφιά είναι ένα φως στην καρδιά.", preset)) return 1;
     // Turkish
-    if (!test_ushx_cd("Güzellik yüzünde değil. Güzellik, kalbin içindeki bir ışıktır.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Güzellik yüzünde değil. Güzellik, kalbin içindeki bir ışıktır.", preset)) return 1;
     // Polish
-    if (!test_ushx_cd("Piękno nie jest na twarzy. Piękno jest światłem w sercu.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Piękno nie jest na twarzy. Piękno jest światłem w sercu.", preset)) return 1;
 
     // Africans
-    if (!test_ushx_cd("Skoonheid is nie in die gesig nie. Skoonheid is 'n lig in die hart.", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("Skoonheid is nie in die gesig nie. Skoonheid is 'n lig in die hart.", preset)) return 1;
     // Swahili
-    if (!test_ushx_cd("Beauty si katika uso. Uzuri ni nuru moyoni.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Beauty si katika uso. Uzuri ni nuru moyoni.", preset)) return 1;
     // Zulu
-    if (!test_ushx_cd("Ubuhle abukho ebusweni. Ubuhle bungukukhanya enhliziyweni.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Ubuhle abukho ebusweni. Ubuhle bungukukhanya enhliziyweni.", preset)) return 1;
     // Somali
-    if (!test_ushx_cd("Beauty ma aha in wajiga. Beauty waa iftiin ah ee wadnaha.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Beauty ma aha in wajiga. Beauty waa iftiin ah ee wadnaha.", preset)) return 1;
 
     // Russian
-    if (!test_ushx_cd("Красота не в лицо. Красота - это свет в сердце.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Красота не в лицо. Красота - это свет в сердце.", preset)) return 1;
     // Arabic
-    if (!test_ushx_cd("الجمال ليس في الوجه. الجمال هو النور الذي في القلب.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("الجمال ليس في الوجه. الجمال هو النور الذي في القلب.", preset)) return 1;
     // Persian
-    if (!test_ushx_cd("زیبایی در چهره نیست. زیبایی نور در قلب است.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("زیبایی در چهره نیست. زیبایی نور در قلب است.", preset)) return 1;
     // Pashto
-    if (!test_ushx_cd("ښکلا په مخ کې نه ده. ښکلا په زړه کی یوه رڼا ده.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("ښکلا په مخ کې نه ده. ښکلا په زړه کی یوه رڼا ده.", preset)) return 1;
     // Azerbaijani
-    if (!test_ushx_cd("Gözəllik üzdə deyil. Gözəllik qəlbdə bir işıqdır.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Gözəllik üzdə deyil. Gözəllik qəlbdə bir işıqdır.", preset)) return 1;
     // Uzbek
-    if (!test_ushx_cd("Go'zallik yuzida emas. Go'zallik - qalbdagi nur.", preset)) return 1;
+    if (preset != 1 && preset != 2 && !test_ushx_cd("Go'zallik yuzida emas. Go'zallik - qalbdagi nur.", preset)) return 1;
     // Kurdish
-    if (!test_ushx_cd("Bedewî ne di rû de ye. Bedewî di dil de ronahiyek e.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Bedewî ne di rû de ye. Bedewî di dil de ronahiyek e.", preset)) return 1;
     // Urdu
-    if (!test_ushx_cd("خوبصورتی چہرے میں نہیں ہے۔ خوبصورتی دل میں روشنی ہے۔", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("خوبصورتی چہرے میں نہیں ہے۔ خوبصورتی دل میں روشنی ہے۔", preset)) return 1;
 
     // Hindi
-    if (!test_ushx_cd("सुंदरता चेहरे में नहीं है। सौंदर्य हृदय में प्रकाश है।", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("सुंदरता चेहरे में नहीं है। सौंदर्य हृदय में प्रकाश है।", preset)) return 1;
     // Bangla
-    if (!test_ushx_cd("সৌন্দর্য মুখে নেই। সৌন্দর্য হৃদয় একটি আলো।", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("সৌন্দর্য মুখে নেই। সৌন্দর্য হৃদয় একটি আলো।", preset)) return 1;
     // Punjabi
-    if (!test_ushx_cd("ਸੁੰਦਰਤਾ ਚਿਹਰੇ ਵਿੱਚ ਨਹੀਂ ਹੈ. ਸੁੰਦਰਤਾ ਦੇ ਦਿਲ ਵਿਚ ਚਾਨਣ ਹੈ.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("ਸੁੰਦਰਤਾ ਚਿਹਰੇ ਵਿੱਚ ਨਹੀਂ ਹੈ. ਸੁੰਦਰਤਾ ਦੇ ਦਿਲ ਵਿਚ ਚਾਨਣ ਹੈ.", preset)) return 1;
     // Telugu
-    if (!test_ushx_cd("అందం ముఖంలో లేదు. అందం హృదయంలో ఒక కాంతి.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("అందం ముఖంలో లేదు. అందం హృదయంలో ఒక కాంతి.", preset)) return 1;
     // Tamil
-    if (!test_ushx_cd("அழகு முகத்தில் இல்லை. அழகு என்பது இதயத்தின் ஒளி.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("அழகு முகத்தில் இல்லை. அழகு என்பது இதயத்தின் ஒளி.", preset)) return 1;
     // Marathi
-    if (!test_ushx_cd("सौंदर्य चेहरा नाही. सौंदर्य हे हृदयातील एक प्रकाश आहे.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("सौंदर्य चेहरा नाही. सौंदर्य हे हृदयातील एक प्रकाश आहे.", preset)) return 1;
     // Kannada
-    if (!test_ushx_cd("ಸೌಂದರ್ಯವು ಮುಖದ ಮೇಲೆ ಇಲ್ಲ. ಸೌಂದರ್ಯವು ಹೃದಯದಲ್ಲಿ ಒಂದು ಬೆಳಕು.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("ಸೌಂದರ್ಯವು ಮುಖದ ಮೇಲೆ ಇಲ್ಲ. ಸೌಂದರ್ಯವು ಹೃದಯದಲ್ಲಿ ಒಂದು ಬೆಳಕು.", preset)) return 1;
     // Gujarati
-    if (!test_ushx_cd("સુંદરતા ચહેરા પર નથી. સુંદરતા હૃદયમાં પ્રકાશ છે.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("સુંદરતા ચહેરા પર નથી. સુંદરતા હૃદયમાં પ્રકાશ છે.", preset)) return 1;
     // Malayalam
-    if (!test_ushx_cd("സൗന്ദര്യം മുഖത്ത് ഇല്ല. സൗന്ദര്യം ഹൃദയത്തിലെ ഒരു പ്രകാശമാണ്.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("സൗന്ദര്യം മുഖത്ത് ഇല്ല. സൗന്ദര്യം ഹൃദയത്തിലെ ഒരു പ്രകാശമാണ്.", preset)) return 1;
     // Nepali
-    if (!test_ushx_cd("सौन्दर्य अनुहारमा छैन। सौन्दर्य मुटुको उज्यालो हो।", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("सौन्दर्य अनुहारमा छैन। सौन्दर्य मुटुको उज्यालो हो।", preset)) return 1;
     // Sinhala
-    if (!test_ushx_cd("රූපලාවන්ය මුහුණේ නොවේ. රූපලාවන්ය හදවත තුළ ඇති ආලෝකය වේ.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("රූපලාවන්ය මුහුණේ නොවේ. රූපලාවන්ය හදවත තුළ ඇති ආලෝකය වේ.", preset)) return 1;
 
     // Chinese
-    if (!test_ushx_cd("美是不是在脸上。 美是心中的亮光。", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("美是不是在脸上。 美是心中的亮光。", preset)) return 1;
     // Javanese
-    if (!test_ushx_cd("Beauty ora ing pasuryan. Kaendahan iku cahya ing sajroning ati.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Beauty ora ing pasuryan. Kaendahan iku cahya ing sajroning ati.", preset)) return 1;
     // Japanese
-    if (!test_ushx_cd("美は顔にありません。美は心の中の光です。", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("美は顔にありません。美は心の中の光です。", preset)) return 1;
     // Filipino
-    if (!test_ushx_cd("Ang kagandahan ay wala sa mukha. Ang kagandahan ay ang ilaw sa puso.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Ang kagandahan ay wala sa mukha. Ang kagandahan ay ang ilaw sa puso.", preset)) return 1;
     // Korean
-    if (!test_ushx_cd("아름다움은 얼굴에 없습니다。아름다움은 마음의 빛입니다。", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("아름다움은 얼굴에 없습니다。아름다움은 마음의 빛입니다。", preset)) return 1;
     // Vietnam
-    if (!test_ushx_cd("Vẻ đẹp không nằm trong khuôn mặt. Vẻ đẹp là ánh sáng trong tim.", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Vẻ đẹp không nằm trong khuôn mặt. Vẻ đẹp là ánh sáng trong tim.", preset)) return 1;
     // Thai
-    if (!test_ushx_cd("ความงามไม่ได้อยู่ที่ใบหน้า ความงามเป็นแสงสว่างในใจ", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("ความงามไม่ได้อยู่ที่ใบหน้า ความงามเป็นแสงสว่างในใจ", preset)) return 1;
     // Burmese
-    if (!test_ushx_cd("အလှအပမျက်နှာပေါ်မှာမဟုတ်ပါဘူး။ အလှအပစိတ်နှလုံးထဲမှာအလင်းကိုဖြစ်ပါတယ်။", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("အလှအပမျက်နှာပေါ်မှာမဟုတ်ပါဘူး။ အလှအပစိတ်နှလုံးထဲမှာအလင်းကိုဖြစ်ပါတယ်။", preset)) return 1;
     // Malay
-    if (!test_ushx_cd("Kecantikan bukan di muka. Kecantikan adalah cahaya di dalam hati.", preset)) return 1;
+    if (preset != 1 && !test_ushx_cd("Kecantikan bukan di muka. Kecantikan adalah cahaya di dalam hati.", preset)) return 1;
 
     // Emoji
-    if (!test_ushx_cd("🤣🤣🤣🤣🤣🤣🤣🤣🤣🤣🤣", preset)) return 1;
-    if (!test_ushx_cd("😀😃😄😁😆😅🤣😂🙂🙃😉😊😇🥰😍🤩😘😗😚😙😋😛😜🤪😝🤑🤗🤭🤫🤔🤐🤨😐😑😶😏😒🙄😬🤥😌😔😪🤤😴😷🤒🤕🤢", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("🤣🤣🤣🤣🤣🤣🤣🤣🤣🤣🤣", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("😀😃😄😁😆😅🤣😂🙂🙃😉😊😇🥰😍🤩😘😗😚😙😋😛😜🤪😝🤑🤗🤭🤫🤔🤐🤨😐😑😶😏😒🙄😬🤥😌😔😪🤤😴😷🤒🤕🤢", preset)) return 1;
 
     // Binary
-    if (!test_ushx_cd("Hello\x80\x83\xAE\xBC\xBD\xBE", preset)) return 1;
+    if (presetForUnicode(preset) && !test_ushx_cd("Hello\x80\x83\xAE\xBC\xBD\xBE", preset)) return 1;
 
     return 0;
 

--- a/test_unishox2.c
+++ b/test_unishox2.c
@@ -441,8 +441,8 @@ if (argv >= 2 && strcmp(args[1], "-t") == 0) {
      char dbuf[128];
      char *hex = ":AAAAAA-bbbbbb";
      const int len = strlen(hex);
-     const int clen = unishox2_compress_lines(hex, len, cbuf, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
-     const int dlen = unishox2_decompress_lines(cbuf, clen, dbuf, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
+     const int clen = unishox2_compress_lines(hex, len, cbuf, sizeof cbuf, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
+     const int dlen = unishox2_decompress_lines(cbuf, clen, dbuf, sizeof dbuf, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
      if (dlen != len) {
        printf("Fail len (template): %d, %d:\n%s\n%s\n", len, dlen, hex, dbuf);
        return 1;

--- a/test_unishox2.c
+++ b/test_unishox2.c
@@ -15,82 +15,82 @@
 
 typedef unsigned char byte;
 
-int unishox2_compress_preset_lines(const char *in, int len, char *out, int olen, int preset, struct us_lnk_lst *prev_lines) {
+int unishox2_compress_preset_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen), int preset, struct us_lnk_lst *prev_lines) {
   switch (preset) {
     case 0:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_DFLT, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_DFLT, prev_lines);
     case 1:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_ONLY, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_ONLY, prev_lines);
     case 2:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_ONLY, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_NUM_ONLY, prev_lines);
     case 3:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
     case 4:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
     case 5:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_ALPHA, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_ALPHA, prev_lines);
     case 6:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_DICT, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_DICT, prev_lines);
     case 7:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_SYM, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_SYM, prev_lines);
     case 8:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_UMLAUT, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_UMLAUT, prev_lines);
     case 9:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_NO_DICT, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_NO_DICT, prev_lines);
     case 10:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_NO_UNI, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_NO_UNI, prev_lines);
     case 11:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
     case 12:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_URL, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_URL, prev_lines);
     case 13:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_JSON, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_JSON, prev_lines);
     case 14:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_JSON_NO_UNI, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_JSON_NO_UNI, prev_lines);
     case 15:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_XML, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_XML, prev_lines);
     case 16:
-      return unishox2_compress_lines(in, len, out, olen, USX_PSET_HTML, prev_lines);
+      return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_HTML, prev_lines);
   }
   return 0;
 }
 
-int unishox2_decompress_preset_lines(const char *in, int len, char *out, int olen, int preset, struct us_lnk_lst *prev_lines) {
+int unishox2_decompress_preset_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen), int preset, struct us_lnk_lst *prev_lines) {
   switch (preset) {
     case 0:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_DFLT, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_DFLT, prev_lines);
     case 1:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_ONLY, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_ONLY, prev_lines);
     case 2:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_ONLY, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_NUM_ONLY, prev_lines);
     case 3:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
     case 4:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
     case 5:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_ALPHA, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_ALPHA, prev_lines);
     case 6:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_DICT, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_DICT, prev_lines);
     case 7:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_SYM, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_SYM, prev_lines);
     case 8:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_UMLAUT, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_FAVOR_UMLAUT, prev_lines);
     case 9:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_NO_DICT, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_NO_DICT, prev_lines);
     case 10:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_NO_UNI, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_NO_UNI, prev_lines);
     case 11:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
     case 12:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_URL, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_URL, prev_lines);
     case 13:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_JSON, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_JSON, prev_lines);
     case 14:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_JSON_NO_UNI, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_JSON_NO_UNI, prev_lines);
     case 15:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_XML, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_XML, prev_lines);
     case 16:
-      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_HTML, prev_lines);
+      return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), USX_PSET_HTML, prev_lines);
   }
   return 0;
 }
@@ -100,13 +100,13 @@ int test_ushx_cd(char *input, int preset) {
   char cbuf[200];
   char dbuf[251];
   int len = (int)strlen(input);
-  int clen = unishox2_compress_preset_lines(input, len, cbuf, sizeof cbuf, preset, NULL);
+  int clen = unishox2_compress_preset_lines(input, len, UNISHOX_API_OUT_AND_LEN(cbuf, sizeof cbuf), preset, NULL);
   if (clen > (int)sizeof cbuf) {
     printf("Compress Overflow\n");
     return 0;
   }
   printf("\n\n");
-  int dlen = unishox2_decompress_preset_lines(cbuf, clen, dbuf, sizeof dbuf, preset, NULL);
+  int dlen = unishox2_decompress_preset_lines(cbuf, clen, UNISHOX_API_OUT_AND_LEN(dbuf, sizeof dbuf), preset, NULL);
   if (dlen > (int)sizeof dbuf) {
     printf("Decompress Overflow\n");
     return 0;
@@ -127,6 +127,7 @@ int test_ushx_cd(char *input, int preset) {
   printf("%s: %d/%d=", input, clen, len);
   printf("%.2f%%\n", perc);
 
+#if (UNISHOX_API_OUT_AND_LEN(0,1)) == 1
   // check compress overflow
   for (int i = 1; i <= 16 && clen - i >= 0; ++i) {
     char cbuf_cut[sizeof cbuf];
@@ -156,6 +157,7 @@ int test_ushx_cd(char *input, int preset) {
       return 0;
     }
   }
+#endif
 
   return 1;
 
@@ -288,7 +290,7 @@ if (argv >= 4 && strcmp(args[1], "-c") == 0) {
    do {
      bytes_read = (int)fread(cbuf, 1, sizeof(cbuf), fp);
      if (bytes_read > 0) {
-        clen = unishox2_compress_preset_lines(cbuf, bytes_read, dbuf, sizeof dbuf, preset, NULL);
+        clen = unishox2_compress_preset_lines(cbuf, bytes_read, UNISHOX_API_OUT_AND_LEN(dbuf, sizeof dbuf), preset, NULL);
         ctot += clen;
         tot_len += bytes_read;
         if (clen > 0) {
@@ -327,7 +329,7 @@ if (argv >= 4 && strcmp(args[1], "-d") == 0) {
      len_to_read += fgetc(fp);
      bytes_read = (int)fread(dbuf, 1, len_to_read, fp);
      if (bytes_read > 0) {
-        dlen = unishox2_decompress_preset_lines(dbuf, bytes_read, cbuf, sizeof cbuf, preset, NULL);
+        dlen = unishox2_decompress_preset_lines(dbuf, bytes_read, UNISHOX_API_OUT_AND_LEN(cbuf, sizeof cbuf), preset, NULL);
         if (dlen > 0) {
            if (dlen != fwrite(cbuf, 1, dlen, wfp)) {
               perror("fwrite");
@@ -385,7 +387,7 @@ if (argv >= 4 && (strcmp(args[1], "-g") == 0 ||
         cur_line->data = (char *) malloc(len + 1);
         strncpy(cur_line->data, cbuf, len);
         cur_line->previous = ll;
-        clen = unishox2_compress_preset_lines(cbuf, len, dbuf, sizeof dbuf, preset, cur_line);
+        clen = unishox2_compress_preset_lines(cbuf, len, UNISHOX_API_OUT_AND_LEN(dbuf, sizeof dbuf), preset, cur_line);
         if (clen > 0) {
             perc = (float)(len-clen);
             perc /= len;
@@ -415,7 +417,7 @@ if (argv >= 4 && (strcmp(args[1], "-g") == 0 ||
         }
         if (len > max_len)
           max_len = len;
-        dlen = unishox2_decompress_preset_lines(dbuf, clen, cbuf, sizeof cbuf - 1, preset, cur_line);
+        dlen = unishox2_decompress_preset_lines(dbuf, clen, UNISHOX_API_OUT_AND_LEN(cbuf, sizeof cbuf - 1), preset, cur_line);
         cbuf[dlen] = 0;
         printf("\n%s\n", cbuf);
       }
@@ -461,8 +463,8 @@ if (argv >= 2 && strcmp(args[1], "-t") == 0) {
      char dbuf[128];
      char *hex = ":AAAAAA-bbbbbb";
      const int len = strlen(hex);
-     const int clen = unishox2_compress_lines(hex, len, cbuf, sizeof cbuf, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
-     const int dlen = unishox2_decompress_lines(cbuf, clen, dbuf, sizeof dbuf, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
+     const int clen = unishox2_compress_lines(hex, len, UNISHOX_API_OUT_AND_LEN(cbuf, sizeof cbuf), USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
+     const int dlen = unishox2_decompress_lines(cbuf, clen, UNISHOX_API_OUT_AND_LEN(dbuf, sizeof dbuf), USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, (const char *[]){":FFFFFF", "-ffffff", 0, 0, 0} , NULL);
      if (dlen != len) {
        printf("Fail len (template): %d, %d:\n%s\n%s\n", len, dlen, hex, dbuf);
        return 1;
@@ -715,10 +717,10 @@ if (argv == 2 || (argv == 3 && atoi(args[2]) > 0)) {
    printf("String: %s, Len:%ld\n", args[1], len);
    //print_string_as_hex(args[1], len);
    memset(cbuf, 0, sizeof(cbuf));
-   ctot = unishox2_compress_preset_lines(args[1], len, cbuf, sizeof cbuf, preset, NULL);
+   ctot = unishox2_compress_preset_lines(args[1], len, UNISHOX_API_OUT_AND_LEN(cbuf, sizeof cbuf), preset, NULL);
    print_compressed(cbuf, ctot);
    memset(dbuf, 0, sizeof(dbuf));
-   dlen = unishox2_decompress_preset_lines(cbuf, ctot, dbuf, sizeof dbuf - 1, preset, NULL);
+   dlen = unishox2_decompress_preset_lines(cbuf, ctot, UNISHOX_API_OUT_AND_LEN(dbuf, sizeof dbuf - 1), preset, NULL);
    dbuf[dlen] = 0;
    printf("\nDecompressed: %s\n", dbuf);
    //print_compressed(dbuf, dlen);

--- a/test_unishox2.c
+++ b/test_unishox2.c
@@ -15,82 +15,82 @@
 
 typedef unsigned char byte;
 
-int unishox2_compress_preset_lines(const char *in, int len, char *out, int preset, struct us_lnk_lst *prev_lines) {
+int unishox2_compress_preset_lines(const char *in, int len, char *out, int olen, int preset, struct us_lnk_lst *prev_lines) {
   switch (preset) {
     case 0:
-      return unishox2_compress_lines(in, len, out, USX_PSET_DFLT, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_DFLT, prev_lines);
     case 1:
-      return unishox2_compress_lines(in, len, out, USX_PSET_ALPHA_ONLY, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_ONLY, prev_lines);
     case 2:
-      return unishox2_compress_lines(in, len, out, USX_PSET_ALPHA_NUM_ONLY, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_ONLY, prev_lines);
     case 3:
-      return unishox2_compress_lines(in, len, out, USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
     case 4:
-      return unishox2_compress_lines(in, len, out, USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
     case 5:
-      return unishox2_compress_lines(in, len, out, USX_PSET_FAVOR_ALPHA, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_ALPHA, prev_lines);
     case 6:
-      return unishox2_compress_lines(in, len, out, USX_PSET_FAVOR_DICT, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_DICT, prev_lines);
     case 7:
-      return unishox2_compress_lines(in, len, out, USX_PSET_FAVOR_SYM, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_SYM, prev_lines);
     case 8:
-      return unishox2_compress_lines(in, len, out, USX_PSET_FAVOR_UMLAUT, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_FAVOR_UMLAUT, prev_lines);
     case 9:
-      return unishox2_compress_lines(in, len, out, USX_PSET_NO_DICT, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_NO_DICT, prev_lines);
     case 10:
-      return unishox2_compress_lines(in, len, out, USX_PSET_NO_UNI, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_NO_UNI, prev_lines);
     case 11:
-      return unishox2_compress_lines(in, len, out, USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
     case 12:
-      return unishox2_compress_lines(in, len, out, USX_PSET_URL, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_URL, prev_lines);
     case 13:
-      return unishox2_compress_lines(in, len, out, USX_PSET_JSON, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_JSON, prev_lines);
     case 14:
-      return unishox2_compress_lines(in, len, out, USX_PSET_JSON_NO_UNI, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_JSON_NO_UNI, prev_lines);
     case 15:
-      return unishox2_compress_lines(in, len, out, USX_PSET_XML, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_XML, prev_lines);
     case 16:
-      return unishox2_compress_lines(in, len, out, USX_PSET_HTML, prev_lines);
+      return unishox2_compress_lines(in, len, out, olen, USX_PSET_HTML, prev_lines);
   }
   return 0;
 }
 
-int unishox2_decompress_preset_lines(const char *in, int len, char *out, int preset, struct us_lnk_lst *prev_lines) {
+int unishox2_decompress_preset_lines(const char *in, int len, char *out, int olen, int preset, struct us_lnk_lst *prev_lines) {
   switch (preset) {
     case 0:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_DFLT, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_DFLT, prev_lines);
     case 1:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_ALPHA_ONLY, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_ONLY, prev_lines);
     case 2:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_ALPHA_NUM_ONLY, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_ONLY, prev_lines);
     case 3:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY, prev_lines);
     case 4:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_ALPHA_NUM_SYM_ONLY_TXT, prev_lines);
     case 5:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_FAVOR_ALPHA, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_ALPHA, prev_lines);
     case 6:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_FAVOR_DICT, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_DICT, prev_lines);
     case 7:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_FAVOR_SYM, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_SYM, prev_lines);
     case 8:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_FAVOR_UMLAUT, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_FAVOR_UMLAUT, prev_lines);
     case 9:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_NO_DICT, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_NO_DICT, prev_lines);
     case 10:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_NO_UNI, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_NO_UNI, prev_lines);
     case 11:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_NO_UNI_FAVOR_TEXT, prev_lines);
     case 12:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_URL, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_URL, prev_lines);
     case 13:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_JSON, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_JSON, prev_lines);
     case 14:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_JSON_NO_UNI, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_JSON_NO_UNI, prev_lines);
     case 15:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_XML, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_XML, prev_lines);
     case 16:
-      return unishox2_decompress_lines(in, len, out, USX_PSET_HTML, prev_lines);
+      return unishox2_decompress_lines(in, len, out, olen, USX_PSET_HTML, prev_lines);
   }
   return 0;
 }
@@ -98,13 +98,22 @@ int unishox2_decompress_preset_lines(const char *in, int len, char *out, int pre
 int test_ushx_cd(char *input, int preset) {
 
   char cbuf[200];
-  char dbuf[250];
+  char dbuf[251];
   int len = (int)strlen(input);
-  int clen = unishox2_compress_preset_lines(input, len, cbuf, preset, NULL);
+  int clen = unishox2_compress_preset_lines(input, len, cbuf, sizeof cbuf, preset, NULL);
+  if (clen > (int)sizeof cbuf) {
+    printf("Compress Overflow\n");
+    return 0;
+  }
   printf("\n\n");
-  int dlen = unishox2_decompress_preset_lines(cbuf, clen, dbuf, preset, NULL);
-  dbuf[dlen] = '\0';
+  int dlen = unishox2_decompress_preset_lines(cbuf, clen, dbuf, sizeof dbuf, preset, NULL);
+  if (dlen > (int)sizeof dbuf) {
+    printf("Decompress Overflow\n");
+    return 0;
+  } else if (dlen < (int)sizeof dbuf)
+    dbuf[dlen] = '\0';
   if (dlen != len) {
+    dbuf[sizeof dbuf - 1] = '\0';
     printf("Fail len: %d, %d:\n%s\n%s\n", len, dlen, input, dbuf);
     return 0;
   }
@@ -117,6 +126,37 @@ int test_ushx_cd(char *input, int preset) {
   perc *= 100;
   printf("%s: %d/%d=", input, clen, len);
   printf("%.2f%%\n", perc);
+
+  // check compress overflow
+  for (int i = 1; i <= 16 && clen - i >= 0; ++i) {
+    char cbuf_cut[sizeof cbuf];
+    const int clen_cut = unishox2_compress_preset_lines(input, len, cbuf_cut, clen - i, preset, NULL);
+    if (clen_cut != clen - i + 1) { // should overflow
+      printf("Fail compress len overflow: %d, %d\n", clen - i, clen_cut);
+      return 0;
+    }
+    if (memcmp(cbuf, cbuf_cut, clen - i)) {
+      printf("Fail compress overflow cmp\n");
+      return 0;
+    }
+  }
+
+  // check decompress overflow
+  for (int i = 1; i <= 16 && len - i >= 0; ++i) {
+    memset(dbuf, 0, sizeof dbuf);
+    dlen = unishox2_decompress_preset_lines(cbuf, clen, dbuf, len - i, preset, NULL);
+    if (dlen != len - i + 1) { // should overflow
+      dbuf[sizeof dbuf - 1] = '\0';
+      printf("Fail decompress len overflow: %d, %d:\n%s\n%s\n", len, dlen, input, dbuf);
+      return 0;
+    }
+    dbuf[len - i] = '\0';
+    if (strncmp(input, dbuf, len - i)) {
+      printf("Fail decompress overflow cmp:\n%s\n%s\n", input, dbuf);
+      return 0;
+    }
+  }
+
   return 1;
 
 }
@@ -233,7 +273,7 @@ if (argv >= 4 && strcmp(args[1], "-c") == 0) {
    do {
      bytes_read = (int)fread(cbuf, 1, sizeof(cbuf), fp);
      if (bytes_read > 0) {
-        clen = unishox2_compress_preset_lines(cbuf, bytes_read, dbuf, preset, NULL);
+        clen = unishox2_compress_preset_lines(cbuf, bytes_read, dbuf, sizeof dbuf, preset, NULL);
         ctot += clen;
         tot_len += bytes_read;
         if (clen > 0) {
@@ -272,7 +312,7 @@ if (argv >= 4 && strcmp(args[1], "-d") == 0) {
      len_to_read += fgetc(fp);
      bytes_read = (int)fread(dbuf, 1, len_to_read, fp);
      if (bytes_read > 0) {
-        dlen = unishox2_decompress_preset_lines(dbuf, bytes_read, cbuf, preset, NULL);
+        dlen = unishox2_decompress_preset_lines(dbuf, bytes_read, cbuf, sizeof cbuf, preset, NULL);
         if (dlen > 0) {
            if (dlen != fwrite(cbuf, 1, dlen, wfp)) {
               perror("fwrite");
@@ -330,7 +370,7 @@ if (argv >= 4 && (strcmp(args[1], "-g") == 0 ||
         cur_line->data = (char *) malloc(len + 1);
         strncpy(cur_line->data, cbuf, len);
         cur_line->previous = ll;
-        clen = unishox2_compress_preset_lines(cbuf, len, dbuf, preset, cur_line);
+        clen = unishox2_compress_preset_lines(cbuf, len, dbuf, sizeof dbuf, preset, cur_line);
         if (clen > 0) {
             perc = (float)(len-clen);
             perc /= len;
@@ -360,7 +400,7 @@ if (argv >= 4 && (strcmp(args[1], "-g") == 0 ||
         }
         if (len > max_len)
           max_len = len;
-        dlen = unishox2_decompress_preset_lines(dbuf, clen, cbuf, preset, cur_line);
+        dlen = unishox2_decompress_preset_lines(dbuf, clen, cbuf, sizeof cbuf - 1, preset, cur_line);
         cbuf[dlen] = 0;
         printf("\n%s\n", cbuf);
       }
@@ -637,10 +677,10 @@ if (argv == 2 || (argv == 3 && atoi(args[2]) > 0)) {
    printf("String: %s, Len:%ld\n", args[1], len);
    //print_string_as_hex(args[1], len);
    memset(cbuf, 0, sizeof(cbuf));
-   ctot = unishox2_compress_preset_lines(args[1], len, cbuf, preset, NULL);
+   ctot = unishox2_compress_preset_lines(args[1], len, cbuf, sizeof cbuf, preset, NULL);
    print_compressed(cbuf, ctot);
    memset(dbuf, 0, sizeof(dbuf));
-   dlen = unishox2_decompress_preset_lines(cbuf, ctot, dbuf, preset, NULL);
+   dlen = unishox2_decompress_preset_lines(cbuf, ctot, dbuf, sizeof dbuf - 1, preset, NULL);
    dbuf[dlen] = 0;
    printf("\nDecompressed: %s\n", dbuf);
    //print_compressed(dbuf, dlen);

--- a/test_unishox2.c
+++ b/test_unishox2.c
@@ -98,12 +98,16 @@ int unishox2_decompress_preset_lines(const char *in, int len, char *out, int pre
 int test_ushx_cd(char *input, int preset) {
 
   char cbuf[200];
-  char dbuf[250];
+  char dbuf[251];
   int len = (int)strlen(input);
   int clen = unishox2_compress_preset_lines(input, len, cbuf, preset, NULL);
   printf("\n\n");
   int dlen = unishox2_decompress_preset_lines(cbuf, clen, dbuf, preset, NULL);
-  dbuf[dlen] = '\0';
+  if (dlen > (int)sizeof dbuf) {
+    printf("Decompress Overflow\n");
+    return 0;
+  } else if (dlen < (int)sizeof dbuf)
+    dbuf[dlen] = '\0';
   if (dlen != len) {
     printf("Fail len: %d, %d:\n%s\n%s\n", len, dlen, input, dbuf);
     return 0;

--- a/unishox2.c
+++ b/unishox2.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdint.h>
+#include <limits.h>
 
 #include "unishox2.h"
 
@@ -405,7 +406,7 @@ void append_final_bits(char *out, int ol, const byte bits[], const int bit_lens[
   if (newidx < 0) return (olen) + 1; \
 } while (0)
 
-int unishox2_compress_lines(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
+int unishox2_compress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen), const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
 
   byte state;
 
@@ -413,6 +414,9 @@ int unishox2_compress_lines(const char *in, int len, char *out, int olen, const 
   char c_in, c_next;
   int prev_uni;
   byte is_upper, is_all_upper;
+#if (UNISHOX_API_OUT_AND_LEN(0,1)) == 0
+  const int olen = INT_MAX - 1;
+#endif
 
   init_coder();
   ol = 0;
@@ -725,12 +729,12 @@ int unishox2_compress_lines(const char *in, int len, char *out, int olen, const 
 
 }
 
-int unishox2_compress(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
-  return unishox2_compress_lines(in, len, out, olen, usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
+int unishox2_compress(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen), const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
+  return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
 }
 
-int unishox2_compress_simple(const char *in, int len, char *out, int olen) {
-  return unishox2_compress_lines(in, len, out, olen, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES, NULL);
+int unishox2_compress_simple(const char *in, int len, char *out) {
+  return unishox2_compress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, INT_MAX - 1), USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES, NULL);
 }
 
 int readBit(const char *in, int bit_no) {
@@ -936,12 +940,15 @@ char getHexChar(int32_t nibble, int hex_type) {
   return 'A' + nibble - 10;
 }
 
-int unishox2_decompress_lines(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
+int unishox2_decompress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen), const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
 
   int dstate;
   int bit_no;
   int h, v;
   byte is_all_upper;
+#if (UNISHOX_API_OUT_AND_LEN(0,1)) == 0
+  const int olen = INT_MAX - 1;
+#endif
 
   init_coder();
   int ol = 0;
@@ -1189,10 +1196,10 @@ int unishox2_decompress_lines(const char *in, int len, char *out, int olen, cons
 
 }
 
-int unishox2_decompress(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
-  return unishox2_decompress_lines(in, len, out, olen, usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
+int unishox2_decompress(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen), const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
+  return unishox2_decompress_lines(in, len, UNISHOX_API_OUT_AND_LEN(out, olen), usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
 }
 
-int unishox2_decompress_simple(const char *in, int len, char *out, int olen) {
-  return unishox2_decompress(in, len, out, olen, USX_PSET_DFLT);
+int unishox2_decompress_simple(const char *in, int len, char *out) {
+  return unishox2_decompress(in, len, UNISHOX_API_OUT_AND_LEN(out, INT_MAX - 1), USX_PSET_DFLT);
 }

--- a/unishox2.c
+++ b/unishox2.c
@@ -95,11 +95,12 @@ void init_coder() {
 }
 
 unsigned int usx_mask[] = {0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE, 0xFF};
-int append_bits(char *out, int ol, byte code, int clen) {
+int append_bits(char *out, int olen, int ol, byte code, int clen) {
 
   byte cur_bit;
   byte blen;
   unsigned char a_byte;
+  int oidx;
 
   //printf("%d,%x,%d,%d\n", ol, code, clen, state);
 
@@ -110,10 +111,13 @@ int append_bits(char *out, int ol, byte code, int clen) {
      a_byte >>= cur_bit;
      if (blen + cur_bit > 8)
         blen = (8 - cur_bit);
+     oidx = ol / 8;
+     if (oidx < 0 || olen <= oidx)
+        return -1;
      if (cur_bit == 0)
-        out[ol / 8] = a_byte;
+        out[oidx] = a_byte;
      else
-        out[ol / 8] |= a_byte;
+        out[oidx] |= a_byte;
      code <<= blen;
      ol += blen;
      clen -= blen;
@@ -121,16 +125,21 @@ int append_bits(char *out, int ol, byte code, int clen) {
    return ol;
 }
 
-int append_switch_code(char *out, int ol, byte state) {
+#define SAFE_APPEND_BITS(exp) do { \
+  const int newidx = (exp); \
+  if (newidx < 0) return newidx; \
+} while (0)
+
+int append_switch_code(char *out, int olen, int ol, byte state) {
   if (state == USX_DELTA) {
-    ol = append_bits(out, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN);
-    ol = append_bits(out, ol, UNI_STATE_SW_CODE, UNI_STATE_SW_CODE_LEN);
+    SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN));
+    SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, UNI_STATE_SW_CODE, UNI_STATE_SW_CODE_LEN));
   } else
-    ol = append_bits(out, ol, SW_CODE, SW_CODE_LEN);
+    SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, SW_CODE, SW_CODE_LEN));
   return ol;
 }
 
-int append_code(char *out, int ol, byte code, byte *state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
+int append_code(char *out, int olen, int ol, byte code, byte *state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
   byte hcode = code >> 5;
   byte vcode = code & 0x1F;
   if (!usx_hcode_lens[hcode] && hcode != USX_ALPHA)
@@ -138,40 +147,41 @@ int append_code(char *out, int ol, byte code, byte *state, const byte usx_hcodes
   switch (hcode) {
     case USX_ALPHA:
       if (*state != USX_ALPHA) {
-        ol = append_switch_code(out, ol, *state);
-        ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
+        SAFE_APPEND_BITS(ol = append_switch_code(out, olen, ol, *state));
+        SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
         *state = USX_ALPHA;
       }
       break;
     case USX_SYM:
-      ol = append_switch_code(out, ol, *state);
-      ol = append_bits(out, ol, usx_hcodes[USX_SYM], usx_hcode_lens[USX_SYM]);
+      SAFE_APPEND_BITS(ol = append_switch_code(out, olen, ol, *state));
+      SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, usx_hcodes[USX_SYM], usx_hcode_lens[USX_SYM]));
       break;
     case USX_NUM:
       if (*state != USX_NUM) {
-        ol = append_switch_code(out, ol, *state);
-        ol = append_bits(out, ol, usx_hcodes[USX_NUM], usx_hcode_lens[USX_NUM]);
+        SAFE_APPEND_BITS(ol = append_switch_code(out, olen, ol, *state));
+        SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, usx_hcodes[USX_NUM], usx_hcode_lens[USX_NUM]));
         if (usx_sets[hcode][vcode] >= '0' && usx_sets[hcode][vcode] <= '9')
           *state = USX_NUM;
       }
   }
-  return append_bits(out, ol, usx_vcodes[vcode], usx_vcode_lens[vcode]);
+  SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, usx_vcodes[vcode], usx_vcode_lens[vcode]));
+  return ol;
 }
 
 const byte count_bit_lens[5] = {2, 4, 7, 11, 16};
 const int32_t count_adder[5] = {4, 20, 148, 2196, 67732};
 const byte count_codes[] = {0x01, 0x82, 0xC3, 0xE4, 0xF4};
-int encodeCount(char *out, int ol, int count) {
+int encodeCount(char *out, int olen, int ol, int count) {
   // First five bits are code and Last three bits of codes represent length
   for (int i = 0; i < 5; i++) {
     if (count < count_adder[i]) {
-      ol = append_bits(out, ol, (count_codes[i] & 0xF8), count_codes[i] & 0x07);
+      SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, (count_codes[i] & 0xF8), count_codes[i] & 0x07));
       uint16_t count16 = (count - (i ? count_adder[i - 1] : 0)) << (16 - count_bit_lens[i]);
       if (count_bit_lens[i] > 8) {
-        ol = append_bits(out, ol, count16 >> 8, 8);
-        ol = append_bits(out, ol, count16 & 0xFF, count_bit_lens[i] - 8);
+        SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, count16 >> 8, 8));
+        SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, count16 & 0xFF, count_bit_lens[i] - 8));
       } else
-        ol = append_bits(out, ol, count16 >> 8, count_bit_lens[i]);
+        SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, count16 >> 8, count_bit_lens[i]));
       return ol;
     }
   }
@@ -181,7 +191,7 @@ int encodeCount(char *out, int ol, int count) {
 const byte uni_bit_len[5] = {6, 12, 14, 16, 21};
 const int32_t uni_adder[5] = {0, 64, 4160, 20544, 86080};
 
-int encodeUnicode(char *out, int ol, int32_t code, int32_t prev_code) {
+int encodeUnicode(char *out, int olen, int ol, int32_t code, int32_t prev_code) {
   // First five bits are code and Last three bits of codes represent length
   //const byte codes[8] = {0x00, 0x42, 0x83, 0xA3, 0xC3, 0xE4, 0xF5, 0xFD};
   const byte codes[6] = {0x01, 0x82, 0xC3, 0xE4, 0xF5, 0xFD};
@@ -194,24 +204,24 @@ int encodeUnicode(char *out, int ol, int32_t code, int32_t prev_code) {
   for (int i = 0; i < 5; i++) {
     till += (1 << uni_bit_len[i]);
     if (diff < till) {
-      ol = append_bits(out, ol, (codes[i] & 0xF8), codes[i] & 0x07);
+      SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, (codes[i] & 0xF8), codes[i] & 0x07));
       //if (diff) {
-        ol = append_bits(out, ol, prev_code > code ? 0x80 : 0, 1);
+        SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, prev_code > code ? 0x80 : 0, 1));
         int32_t val = diff - uni_adder[i];
         //printf("Val: %d\n", val);
         if (uni_bit_len[i] > 16) {
           val <<= (24 - uni_bit_len[i]);
-          ol = append_bits(out, ol, val >> 16, 8);
-          ol = append_bits(out, ol, (val >> 8) & 0xFF, 8);
-          ol = append_bits(out, ol, val & 0xFF, uni_bit_len[i] - 16);
+          SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, val >> 16, 8));
+          SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, (val >> 8) & 0xFF, 8));
+          SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, val & 0xFF, uni_bit_len[i] - 16));
         } else
         if (uni_bit_len[i] > 8) {
           val <<= (16 - uni_bit_len[i]);
-          ol = append_bits(out, ol, val >> 8, 8);
-          ol = append_bits(out, ol, val & 0xFF, uni_bit_len[i] - 8);
+          SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, val >> 8, 8));
+          SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, val & 0xFF, uni_bit_len[i] - 8));
         } else {
           val <<= (8 - uni_bit_len[i]);
-          ol = append_bits(out, ol, val & 0xFF, uni_bit_len[i]);
+          SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, val & 0xFF, uni_bit_len[i]));
         }
       return ol;
     }
@@ -256,7 +266,7 @@ int32_t readUTF8(const char *in, int len, int l, int *utf8len) {
   return ret;
 }
 
-int matchOccurance(const char *in, int len, int l, char *out, int *ol, byte *state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
+int matchOccurance(const char *in, int len, int l, char *out, int olen, int *ol, byte *state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
   int j, k;
   int longest_dist = 0;
   int longest_len = 0;
@@ -279,11 +289,11 @@ int matchOccurance(const char *in, int len, int l, char *out, int *ol, byte *sta
     }
   }
   if (longest_len) {
-    *ol = append_switch_code(out, *ol, *state);
-    *ol = append_bits(out, *ol, usx_hcodes[USX_DICT], usx_hcode_lens[USX_DICT]);
+    SAFE_APPEND_BITS(*ol = append_switch_code(out, olen, *ol, *state));
+    SAFE_APPEND_BITS(*ol = append_bits(out, olen, *ol, usx_hcodes[USX_DICT], usx_hcode_lens[USX_DICT]));
     //printf("Len:%d / Dist:%d/%.*s\n", longest_len, longest_dist, longest_len + NICE_LEN, in + l - longest_dist - NICE_LEN + 1);
-    *ol = encodeCount(out, *ol, longest_len);
-    *ol = encodeCount(out, *ol, longest_dist);
+    SAFE_APPEND_BITS(*ol = encodeCount(out, olen, *ol, longest_len));
+    SAFE_APPEND_BITS(*ol = encodeCount(out, olen, *ol, longest_dist));
     l += (longest_len + NICE_LEN);
     l--;
     return l;
@@ -291,7 +301,7 @@ int matchOccurance(const char *in, int len, int l, char *out, int *ol, byte *sta
   return -l;
 }
 
-int matchLine(const char *in, int len, int l, char *out, int *ol, struct us_lnk_lst *prev_lines, byte *state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
+int matchLine(const char *in, int len, int l, char *out, int olen, int *ol, struct us_lnk_lst *prev_lines, byte *state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
   int last_ol = *ol;
   int last_len = 0;
   int last_dist = 0;
@@ -323,11 +333,11 @@ int matchLine(const char *in, int len, int l, char *out, int *ol, struct us_lnk_
         last_len = (k - j);
         last_dist = j;
         last_ctx = line_ctr;
-        *ol = append_switch_code(out, *ol, *state);
-        *ol = append_bits(out, *ol, usx_hcodes[USX_DICT], usx_hcode_lens[USX_DICT]);
-        *ol = encodeCount(out, *ol, last_len - NICE_LEN);
-        *ol = encodeCount(out, *ol, last_dist);
-        *ol = encodeCount(out, *ol, last_ctx);
+        SAFE_APPEND_BITS(*ol = append_switch_code(out, olen, *ol, *state));
+        SAFE_APPEND_BITS(*ol = append_bits(out, olen, *ol, usx_hcodes[USX_DICT], usx_hcode_lens[USX_DICT]));
+        SAFE_APPEND_BITS(*ol = encodeCount(out, olen, *ol, last_len - NICE_LEN));
+        SAFE_APPEND_BITS(*ol = encodeCount(out, olen, *ol, last_dist));
+        SAFE_APPEND_BITS(*ol = encodeCount(out, olen, *ol, last_ctx));
         /*
         if ((*ol - last_ol) > (last_len * 4)) {
           last_len = 0;
@@ -369,14 +379,14 @@ char getNibbleType(char ch) {
   return USX_NIB_NOT;
 }
 
-int append_nibble_escape(char *out, int ol, byte state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
-  ol = append_switch_code(out, ol, state);
-  ol = append_bits(out, ol, usx_hcodes[USX_NUM], usx_hcode_lens[USX_NUM]);
-  ol = append_bits(out, ol, 0, 2);
+int append_nibble_escape(char *out, int olen, int ol, byte state, const byte usx_hcodes[], const byte usx_hcode_lens[]) {
+  SAFE_APPEND_BITS(ol = append_switch_code(out, olen, ol, state));
+  SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, usx_hcodes[USX_NUM], usx_hcode_lens[USX_NUM]));
+  SAFE_APPEND_BITS(ol = append_bits(out, olen, ol, 0, 2));
   return ol;
 }
 
-int min_of(char c, int i) {
+long min_of(long c, long i) {
   return c > i ? i : c;
 }
 
@@ -384,13 +394,18 @@ void append_final_bits(char *out, int ol, const byte bits[], const int bit_lens[
   char remain_bits = 8 - (ol % 8);
   for (int i = 0; i < 4; i++) {
     if (bit_lens[i] && remain_bits > 0) {
-      ol = append_bits(out, ol, bits[i], min_of(remain_bits, bit_lens[i]));
+      ol = append_bits(out, (ol+7) / 8, ol, bits[i], min_of(remain_bits, bit_lens[i]));
       remain_bits -= bit_lens[i];
     }
   }
 }
 
-int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
+#define SAFE_APPEND_BITS2(olen, exp) do { \
+  const int newidx = (exp); \
+  if (newidx < 0) return (olen) + 1; \
+} while (0)
+
+int unishox2_compress_lines(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
 
   byte state;
 
@@ -404,20 +419,24 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
   prev_uni = 0;
   state = USX_ALPHA;
   is_all_upper = 0;
-  ol = append_bits(out, ol, 0x80, 1); // magic bit
+  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0x80, 1)); // magic bit
   for (l=0; l<len; l++) {
 
     if (usx_hcode_lens[USX_DICT] && l < (len - NICE_LEN + 1)) {
       if (prev_lines) {
-        l = matchLine(in, len, l, out, &ol, prev_lines, &state, usx_hcodes, usx_hcode_lens);
+        l = matchLine(in, len, l, out, olen, &ol, prev_lines, &state, usx_hcodes, usx_hcode_lens);
         if (l > 0) {
           continue;
+        } else if (l < 0 && ol < 0) {
+          return olen + 1;
         }
         l = -l;
       } else {
-          l = matchOccurance(in, len, l, out, &ol, &state, usx_hcodes, usx_hcode_lens);
+          l = matchOccurance(in, len, l, out, olen, &ol, &state, usx_hcodes, usx_hcode_lens);
           if (l > 0) {
             continue;
+          } else if (l < 0 && ol < 0) {
+            return olen + 1;
           }
           l = -l;
       }
@@ -430,8 +449,8 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
         while (rpt_count < len && in[rpt_count] == c_in)
           rpt_count++;
         rpt_count -= l;
-        ol = append_code(out, ol, RPT_CODE, &state, usx_hcodes, usx_hcode_lens);
-        ol = encodeCount(out, ol, rpt_count - 4);
+        SAFE_APPEND_BITS2(olen, ol = append_code(out, olen, ol, RPT_CODE, &state, usx_hcodes, usx_hcode_lens));
+        SAFE_APPEND_BITS2(olen, ol = encodeCount(out, olen, ol, rpt_count - 4));
         l += rpt_count;
         l--;
         continue;
@@ -456,13 +475,13 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
           }
         }
         if (uid_pos == l + 36) {
-          ol = append_nibble_escape(out, ol, state, usx_hcodes, usx_hcode_lens);
-          ol = append_bits(out, ol, (hex_type == USX_NIB_HEX_LOWER ? 0xC0 : 0xF0),
-                 (hex_type == USX_NIB_HEX_LOWER ? 3 : 5));
+          SAFE_APPEND_BITS2(olen, ol = append_nibble_escape(out, olen, ol, state, usx_hcodes, usx_hcode_lens));
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, (hex_type == USX_NIB_HEX_LOWER ? 0xC0 : 0xF0),
+                 (hex_type == USX_NIB_HEX_LOWER ? 3 : 5)));
           for (uid_pos = l; uid_pos < l + 36; uid_pos++) {
             char c_uid = in[uid_pos];
             if (c_uid != '-')
-              ol = append_bits(out, ol, getBaseCode(c_uid), 4);
+              SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, getBaseCode(c_uid), 4));
           }
           //printf("GUID:\n");
           l += 35;
@@ -488,11 +507,11 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
       if (hex_len > 10 && hex_type == USX_NIB_NUM)
         hex_type = USX_NIB_HEX_LOWER;
       if ((hex_type == USX_NIB_HEX_LOWER || hex_type == USX_NIB_HEX_UPPER) && hex_len > 3) {
-        ol = append_nibble_escape(out, ol, state, usx_hcodes, usx_hcode_lens);
-        ol = append_bits(out, ol, (hex_type == USX_NIB_HEX_LOWER ? 0x80 : 0xE0), (hex_type == USX_NIB_HEX_LOWER ? 2 : 4));
-        ol = encodeCount(out, ol, hex_len);
+        SAFE_APPEND_BITS2(olen, ol = append_nibble_escape(out, olen, ol, state, usx_hcodes, usx_hcode_lens));
+        SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, (hex_type == USX_NIB_HEX_LOWER ? 0x80 : 0xE0), (hex_type == USX_NIB_HEX_LOWER ? 2 : 4)));
+        SAFE_APPEND_BITS2(olen, ol = encodeCount(out, olen, ol, hex_len));
         do {
-          ol = append_bits(out, ol, getBaseCode(in[l++]), 4);
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, getBaseCode(in[l++]), 4));
         } while (--hex_len);
         l--;
         continue;
@@ -524,17 +543,17 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
           if (((float)j / rem) > 0.66) {
             //printf("%s\n", usx_templates[i]);
             rem = rem - j;
-            ol = append_nibble_escape(out, ol, state, usx_hcodes, usx_hcode_lens);
-            ol = append_bits(out, ol, 0, 1);
-            ol = append_bits(out, ol, (count_codes[i] & 0xF8), count_codes[i] & 0x07);
-            ol = encodeCount(out, ol, rem);
+            SAFE_APPEND_BITS2(olen, ol = append_nibble_escape(out, olen, ol, state, usx_hcodes, usx_hcode_lens));
+            SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0, 1));
+            SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, (count_codes[i] & 0xF8), count_codes[i] & 0x07));
+            SAFE_APPEND_BITS2(olen, ol = encodeCount(out, olen, ol, rem));
             for (int k = 0; k < j; k++) {
               char c_t = usx_templates[i][k];
               if (c_t == 'f' || c_t == 'F')
-                ol = append_bits(out, ol, getBaseCode(in[l + k]), 4);
+                SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, getBaseCode(in[l + k]), 4));
               else if (c_t == 'r' || c_t == 't' || c_t == 'o') {
                 c_t = (c_t == 'r' ? 3 : (c_t == 't' ? 2 : 1));
-                ol = append_bits(out, ol, (in[l + k] - '0') << (8 - c_t), c_t);
+                SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, (in[l + k] - '0') << (8 - c_t), c_t));
               }
             }
             l += j;
@@ -553,7 +572,7 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
         int seq_len = (int)strlen(usx_freq_seq[i]);
         if (len - seq_len >= 0 && l <= len - seq_len) {
           if (memcmp(usx_freq_seq[i], in + l, seq_len) == 0 && usx_hcode_lens[usx_freq_codes[i] >> 5]) {
-            ol = append_code(out, ol, usx_freq_codes[i], &state, usx_hcodes, usx_hcode_lens);
+            SAFE_APPEND_BITS2(olen, ol = append_code(out, olen, ol, usx_freq_codes[i], &state, usx_hcodes, usx_hcode_lens));
             l += seq_len;
             l--;
             break;
@@ -572,23 +591,23 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
     else {
       if (is_all_upper) {
         is_all_upper = 0;
-        ol = append_switch_code(out, ol, state);
-        ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
+        SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+        SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
         state = USX_ALPHA;
       }
     }
     if (is_upper && !is_all_upper) {
       if (state == USX_NUM) {
-        ol = append_switch_code(out, ol, state);
-        ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
+        SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+        SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
         state = USX_ALPHA;
       }
-      ol = append_switch_code(out, ol, state);
-      ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
+      SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+      SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
       if (state == USX_DELTA) {
         state = USX_ALPHA;
-        ol = append_switch_code(out, ol, state);
-        ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
+        SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+        SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
       }
     }
     c_next = 0;
@@ -602,8 +621,8 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
             break;
         }
         if (ll == l-1) {
-          ol = append_switch_code(out, ol, state);
-          ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
+          SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
           state = USX_ALPHA;
           is_all_upper = 1;
         }
@@ -612,8 +631,8 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
         byte spl_code = (c_in == ',' ? 0xC0 : (c_in == '.' ? 0xE0 : (c_in == ' ' ? 0 : 0xFF)));
         if (spl_code != 0xFF) {
           byte spl_code_len = (c_in == ',' ? 3 : (c_in == '.' ? 4 : (c_in == ' ' ? 1 : 4)));
-          ol = append_bits(out, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN);
-          ol = append_bits(out, ol, spl_code, spl_code_len);
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN));
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, spl_code, spl_code_len));
           continue;
         }
       }
@@ -622,30 +641,30 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
         c_in += 32;
       if (c_in == 0) {
         if (state == USX_NUM)
-          ol = append_bits(out, ol, usx_vcodes[NUM_SPC_CODE & 0x1F], usx_vcode_lens[NUM_SPC_CODE & 0x1F]);
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_vcodes[NUM_SPC_CODE & 0x1F], usx_vcode_lens[NUM_SPC_CODE & 0x1F]));
         else
-          ol = append_bits(out, ol, usx_vcodes[1], usx_vcode_lens[1]);
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_vcodes[1], usx_vcode_lens[1]));
       } else {
         c_in--;
-        ol = append_code(out, ol, usx_code_94[(int)c_in], &state, usx_hcodes, usx_hcode_lens);
+        SAFE_APPEND_BITS2(olen, ol = append_code(out, olen, ol, usx_code_94[(int)c_in], &state, usx_hcodes, usx_hcode_lens));
       }
     } else
     if (c_in == 13 && c_next == 10) {
-      ol = append_code(out, ol, CRLF_CODE, &state, usx_hcodes, usx_hcode_lens);
+      SAFE_APPEND_BITS2(olen, ol = append_code(out, olen, ol, CRLF_CODE, &state, usx_hcodes, usx_hcode_lens));
       l++;
     } else
     if (c_in == 10) {
       if (state == USX_DELTA) {
-        ol = append_bits(out, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN);
-        ol = append_bits(out, ol, 0xF0, 4);
+        SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, UNI_STATE_SPL_CODE, UNI_STATE_SPL_CODE_LEN));
+        SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0xF0, 4));
       } else
-        ol = append_code(out, ol, LF_CODE, &state, usx_hcodes, usx_hcode_lens);
+        SAFE_APPEND_BITS2(olen, ol = append_code(out, olen, ol, LF_CODE, &state, usx_hcodes, usx_hcode_lens));
     } else
     if (c_in == 13) {
-      ol = append_code(out, ol, CR_CODE, &state, usx_hcodes, usx_hcode_lens);
+      SAFE_APPEND_BITS2(olen, ol = append_code(out, olen, ol, CR_CODE, &state, usx_hcodes, usx_hcode_lens));
     } else
     if (c_in == '\t') {
-      ol = append_code(out, ol, TAB_CODE, &state, usx_hcodes, usx_hcode_lens);
+      SAFE_APPEND_BITS2(olen, ol = append_code(out, olen, ol, TAB_CODE, &state, usx_hcodes, usx_hcode_lens));
     } else {
       int utf8len;
       int32_t uni = readUTF8(in, len, l, &utf8len);
@@ -655,19 +674,19 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
           int32_t uni2 = readUTF8(in, len, l, &utf8len);
           if (uni2) {
             if (state != USX_ALPHA) {
-              ol = append_switch_code(out, ol, state);
-              ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
+              SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+              SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
             }
-            ol = append_switch_code(out, ol, state);
-            ol = append_bits(out, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]);
-            ol = append_bits(out, ol, usx_vcodes[1], usx_vcode_lens[1]); // code for space (' ')
+            SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+            SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_ALPHA], usx_hcode_lens[USX_ALPHA]));
+            SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_vcodes[1], usx_vcode_lens[1])); // code for space (' ')
             state = USX_DELTA;
           } else {
-            ol = append_switch_code(out, ol, state);
-            ol = append_bits(out, ol, usx_hcodes[USX_DELTA], usx_hcode_lens[USX_DELTA]);
+            SAFE_APPEND_BITS2(olen, ol = append_switch_code(out, olen, ol, state));
+            SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, usx_hcodes[USX_DELTA], usx_hcode_lens[USX_DELTA]));
           }
         }
-        ol = encodeUnicode(out, ol, uni, prev_uni);
+        SAFE_APPEND_BITS2(olen, ol = encodeUnicode(out, olen, ol, uni, prev_uni));
         //printf("%d:%d:%d\n", l, utf8len, uni);
         prev_uni = uni;
         l--;
@@ -684,11 +703,11 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
           bin_count++;
         }
         //printf("Bin:%d:%d:%x:%d\n", l, (unsigned char) c_in, (unsigned char) c_in, bin_count);
-        ol = append_nibble_escape(out, ol, state, usx_hcodes, usx_hcode_lens);
-        ol = append_bits(out, ol, 0xF8, 5);
-        ol = encodeCount(out, ol, bin_count);
+        SAFE_APPEND_BITS2(olen, ol = append_nibble_escape(out, olen, ol, state, usx_hcodes, usx_hcode_lens));
+        SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0xF8, 5));
+        SAFE_APPEND_BITS2(olen, ol = encodeCount(out, olen, ol, bin_count));
         do {
-          ol = append_bits(out, ol, in[l++], 8);
+          SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, in[l++], 8));
         } while (--bin_count);
         l--;
       }
@@ -706,12 +725,12 @@ int unishox2_compress_lines(const char *in, int len, char *out, const byte usx_h
 
 }
 
-int unishox2_compress(const char *in, int len, char *out, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
-  return unishox2_compress_lines(in, len, out, usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
+int unishox2_compress(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
+  return unishox2_compress_lines(in, len, out, olen, usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
 }
 
-int unishox2_compress_simple(const char *in, int len, char *out) {
-  return unishox2_compress_lines(in, len, out, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES, NULL);
+int unishox2_compress_simple(const char *in, int len, char *out, int olen) {
+  return unishox2_compress_lines(in, len, out, olen, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES, NULL);
 }
 
 int readBit(const char *in, int bit_no) {
@@ -798,23 +817,22 @@ int getStepCodeIdx(const char *in, int len, int *bit_no_p, int limit) {
   return idx;
 }
 
-// TODO: Check length
 int32_t getNumFromBits(const char *in, int len, int bit_no, int count) {
    int32_t ret = 0;
    while (count-- && bit_no < len) {
      ret += (readBit(in, bit_no) ? 1 << count : 0);
      bit_no++;
    }
-   return ret;
+   return count < 0 ? ret : -1;
 }
 
-int readCount(const char *in, int *bit_no_p, int len) {
+int32_t readCount(const char *in, int *bit_no_p, int len) {
   int idx = getStepCodeIdx(in, len, bit_no_p, 4);
   if (idx == 99)
     return -1;
   if (*bit_no_p + count_bit_lens[idx] - 1 >= len)
     return -1;
-  int count = getNumFromBits(in, len, *bit_no_p, count_bit_lens[idx]) + (idx ? count_adder[idx - 1] : 0);
+  int32_t count = getNumFromBits(in, len, *bit_no_p, count_bit_lens[idx]) + (idx ? count_adder[idx - 1] : 0);
   (*bit_no_p) += count_bit_lens[idx];
   return count;
 }
@@ -841,54 +859,78 @@ int32_t readUnicode(const char *in, int *bit_no_p, int len) {
   return 0;
 }
 
-void writeUTF8(char *out, int *ol, int uni) {
+#define DEC_OUTPUT_CHAR(out, olen, ol, c) do { \
+  char *const obuf = (out); \
+  const int oidx = (ol); \
+  const int limit = (olen); \
+  if (limit <= oidx) return limit + 1; \
+  else if (oidx < 0) return 0; \
+  else obuf[oidx] = (c); \
+} while (0)
+
+#define DEC_OUTPUT_CHARS(olen, exp) do { \
+  const int newidx = (exp); \
+  const int limit = (olen); \
+  if (newidx > limit) return limit + 1; \
+} while (0)
+
+int writeUTF8(char *out, int olen, int ol, int uni) {
   if (uni < (1 << 11)) {
-    out[(*ol)++] = (0xC0 + (uni >> 6));
-    out[(*ol)++] = (0x80 + (uni & 0x3F));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0xC0 + (uni >> 6));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0x80 + (uni & 0x3F));
   } else
   if (uni < (1 << 16)) {
-    out[(*ol)++] = (0xE0 + (uni >> 12));
-    out[(*ol)++] = (0x80 + ((uni >> 6) & 0x3F));
-    out[(*ol)++] = (0x80 + (uni & 0x3F));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0xE0 + (uni >> 12));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0x80 + ((uni >> 6) & 0x3F));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0x80 + (uni & 0x3F));
   } else {
-    out[(*ol)++] = (0xF0 + (uni >> 18));
-    out[(*ol)++] = (0x80 + ((uni >> 12) & 0x3F));
-    out[(*ol)++] = (0x80 + ((uni >> 6) & 0x3F));
-    out[(*ol)++] = (0x80 + (uni & 0x3F));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0xF0 + (uni >> 18));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0x80 + ((uni >> 12) & 0x3F));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0x80 + ((uni >> 6) & 0x3F));
+    DEC_OUTPUT_CHAR(out, olen, ol++, 0x80 + (uni & 0x3F));
   }
+  return ol;
 }
 
-int decodeRepeat(const char *in, int len, char *out, int ol, int *bit_no, struct us_lnk_lst *prev_lines) {
+int decodeRepeat(const char *in, int len, char *out, int olen, int ol, int *bit_no, struct us_lnk_lst *prev_lines) {
   if (prev_lines) {
-    int dict_len = readCount(in, bit_no, len) + NICE_LEN;
-    if (dict_len < 0)
+    int32_t dict_len = readCount(in, bit_no, len) + NICE_LEN;
+    if (dict_len < NICE_LEN)
       return ol;
-    int dist = readCount(in, bit_no, len);
+    int32_t dist = readCount(in, bit_no, len);
     if (dist < 0)
       return ol;
-    int ctx = readCount(in, bit_no, len);
+    int32_t ctx = readCount(in, bit_no, len);
     if (ctx < 0)
       return ol;
     struct us_lnk_lst *cur_line = prev_lines;
+    const int left = olen - ol;
     while (ctx--)
       cur_line = cur_line->previous;
-    memmove(out + ol, cur_line->data + dist, dict_len);
+    if (left <= 0) return olen + 1;
+    memmove(out + ol, cur_line->data + dist, min_of(left, dict_len));
+    if (left < dict_len) return olen + 1;
     ol += dict_len;
   } else {
-    int dict_len = readCount(in, bit_no, len) + NICE_LEN;
-    if (dict_len < 0)
+    int32_t dict_len = readCount(in, bit_no, len) + NICE_LEN;
+    if (dict_len < NICE_LEN)
       return ol;
-    int dist = readCount(in, bit_no, len) + NICE_LEN - 1;
+    int32_t dist = readCount(in, bit_no, len) + NICE_LEN - 1;
+    if (dist < NICE_LEN - 1)
+      return ol;
+    const int32_t left = olen - ol;
     if (dist < 0)
       return ol;
     //printf("Decode len: %d, dist: %d\n", dict_len - NICE_LEN, dist - NICE_LEN + 1);
-    memcpy(out + ol, out + ol - dist, dict_len);
+    if (left <= 0) return olen + 1;
+    memmove(out + ol, out + ol - dist, min_of(left, dict_len));
+    if (left < dict_len) return olen + 1;
     ol += dict_len;
   }
   return ol;
 }
 
-char getHexChar(int nibble, int hex_type) {
+char getHexChar(int32_t nibble, int hex_type) {
   if (nibble >= 0 && nibble <= 9)
     return '0' + nibble;
   else if (hex_type < 3)
@@ -896,7 +938,7 @@ char getHexChar(int nibble, int hex_type) {
   return 'A' + nibble - 10;
 }
 
-int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
+int unishox2_decompress_lines(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[], struct us_lnk_lst *prev_lines) {
 
   int dstate;
   int bit_no;
@@ -912,7 +954,6 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
   int prev_uni = 0;
 
   len <<= 3;
-  out[ol] = 0;
   while (bit_no < len) {
     int orig_bit_no = bit_no;
     if (dstate == USX_DELTA || h == USX_DELTA) {
@@ -925,7 +966,7 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
           break;
         switch (spl_code_idx) {
           case 0:
-            out[ol++] = ' ';
+            DEC_OUTPUT_CHAR(out, olen, ol++, ' ');
             continue;
           case 1:
             h = readHCodeIdx(in, len, &bit_no, usx_hcodes, usx_hcode_lens);
@@ -938,24 +979,24 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
               continue;
             }
             if (h == USX_DICT) {
-              ol = decodeRepeat(in, len, out, ol, &bit_no, prev_lines);
+              DEC_OUTPUT_CHARS(olen, ol = decodeRepeat(in, len, out, olen, ol, &bit_no, prev_lines));
               h = dstate;
               continue;
             }
             break;
           case 2:
-            out[ol++] = ',';
+            DEC_OUTPUT_CHAR(out, olen, ol++, ',');
             continue;
           case 3:
-            out[ol++] = '.';
+            DEC_OUTPUT_CHAR(out, olen, ol++, '.');
             continue;
           case 4:
-            out[ol++] = 10;
+            DEC_OUTPUT_CHAR(out, olen, ol++, 10);
             continue;
         }
       } else {
         prev_uni += delta;
-        writeUTF8(out, &ol, prev_uni);
+        DEC_OUTPUT_CHARS(olen, ol = writeUTF8(out, olen, ol, prev_uni));
         //printf("%ld, ", prev_uni);
       }
       if (dstate == USX_DELTA && h == USX_DELTA)
@@ -1008,7 +1049,7 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
          }
       } else
       if (h == USX_DICT) {
-        ol = decodeRepeat(in, len, out, ol, &bit_no, prev_lines);
+        DEC_OUTPUT_CHARS(olen, ol = decodeRepeat(in, len, out, olen, ol, &bit_no, prev_lines));
         continue;
       } else
       if (h == USX_DELTA) {
@@ -1027,45 +1068,63 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
           int idx = getStepCodeIdx(in, len, &bit_no, 5);
           if (idx == 0) {
             idx = getStepCodeIdx(in, len, &bit_no, 4);
-            int rem = readCount(in, &bit_no, len);
+            int32_t rem = readCount(in, &bit_no, len);
             if (rem < 0)
               break;
             rem = (int)strlen(usx_templates[idx]) - rem;
+            int eof = 0;
             for (int j = 0; j < rem; j++) {
               char c_t = usx_templates[idx][j];
               if (c_t == 'f' || c_t == 'r' || c_t == 't' || c_t == 'o' || c_t == 'F') {
                   char nibble_len = (c_t == 'f' || c_t == 'F' ? 4 : (c_t == 'r' ? 3 : (c_t == 't' ? 2 : 1)));
-                  out[ol++] = getHexChar(getNumFromBits(in, len, bit_no, nibble_len),
-                      c_t == 'f' ? USX_NIB_HEX_LOWER : USX_NIB_HEX_UPPER);
+                  const int32_t raw_char = getNumFromBits(in, len, bit_no, nibble_len);
+                  if (raw_char < 0) {
+                      eof = 1;
+                      break;
+                  }
+                  DEC_OUTPUT_CHAR(out, olen, ol++, getHexChar((char)raw_char,
+                      c_t == 'f' ? USX_NIB_HEX_LOWER : USX_NIB_HEX_UPPER));
                   bit_no += nibble_len;
               } else
-                out[ol++] = c_t;
+                DEC_OUTPUT_CHAR(out, olen, ol++, c_t);
             }
+            if (eof) break; // reach input eof
           } else
           if (idx == 5) {
-            int bin_count = readCount(in, &bit_no, len);
+            int32_t bin_count = readCount(in, &bit_no, len);
             if (bin_count < 0)
               break;
+            if (bin_count == 0) // invalid encoding
+              break;
             do {
-              out[ol++] = getNumFromBits(in, len, bit_no, 8);
+              const int32_t raw_char = getNumFromBits(in, len, bit_no, 8);
+              if (raw_char < 0)
+                  break;
+              DEC_OUTPUT_CHAR(out, olen, ol++, (char)raw_char);
               bit_no += 8;
             } while (--bin_count);
+            if (bin_count > 0) break; // reach input eof
           } else {
-            int nibble_count = 0;
+            int32_t nibble_count = 0;
             if (idx == 2 || idx == 4)
               nibble_count = 32;
             else {
               nibble_count = readCount(in, &bit_no, len);
               if (nibble_count < 0)
                 break;
+              if (nibble_count == 0) // invalid encoding
+                break;
             }
             do {
-              int nibble = (int) getNumFromBits(in, len, bit_no, 4);
-              out[ol++] = getHexChar(nibble, idx);
+              int32_t nibble = getNumFromBits(in, len, bit_no, 4);
+              if (nibble < 0)
+                  break;
+              DEC_OUTPUT_CHAR(out, olen, ol++, getHexChar(nibble, idx));
               if ((idx == 2 || idx == 4) && (nibble_count == 25 || nibble_count == 21 || nibble_count == 17 || nibble_count == 13))
-                out[ol++] = '-';
+                DEC_OUTPUT_CHAR(out, olen, ol++, '-');
               bit_no += 4;
             } while (--nibble_count);
+            if (nibble_count > 0) break; // reach input eof
           }
           if (dstate == USX_DELTA)
             h = USX_DELTA;
@@ -1088,24 +1147,34 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
         dstate = USX_NUM;
       } else if (c == 0) {
         if (v == 8) {
-          out[ol++] = '\r';
-          out[ol++] = '\n';
+          DEC_OUTPUT_CHAR(out, olen, ol++, '\r');
+          DEC_OUTPUT_CHAR(out, olen, ol++, '\n');
         } else if (h == USX_NUM && v == 26) {
-          int count = readCount(in, &bit_no, len);
+          int32_t count = readCount(in, &bit_no, len);
           if (count < 0)
             break;
           count += 4;
+          if (ol <= 0)
+            return 0; // invalid encoding
           char rpt_c = out[ol - 1];
           while (count--)
-            out[ol++] = rpt_c;
+            DEC_OUTPUT_CHAR(out, olen, ol++, rpt_c);
         } else if (h == USX_SYM && v > 24) {
           v -= 25;
-          memcpy(out + ol, usx_freq_seq[v], strlen(usx_freq_seq[v]));
-          ol += (int)strlen(usx_freq_seq[v]);
+          const int freqlen = (int)strlen(usx_freq_seq[v]);
+          const int left = olen - ol;
+          if (left <= 0) return olen + 1;
+          memcpy(out + ol, usx_freq_seq[v], min_of(left, freqlen));
+          if (left < freqlen) return olen + 1;
+          ol += freqlen;
         } else if (h == USX_NUM && v > 22 && v < 26) {
           v -= (23 - 3);
-          memcpy(out + ol, usx_freq_seq[v], strlen(usx_freq_seq[v]));
-          ol += (int)strlen(usx_freq_seq[v]);
+          const int freqlen = (int)strlen(usx_freq_seq[v]);
+          const int left = olen - ol;
+          if (left <= 0) return olen + 1;
+          memcpy(out + ol, usx_freq_seq[v], min_of(left, freqlen));
+          if (left < freqlen) return olen + 1;
+          ol += freqlen;
         } else
           break; // Terminator
         if (dstate == USX_DELTA)
@@ -1115,17 +1184,17 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
     }
     if (dstate == USX_DELTA)
       h = USX_DELTA;
-    out[ol++] = c;
+    DEC_OUTPUT_CHAR(out, olen, ol++, c);
   }
 
   return ol;
 
 }
 
-int unishox2_decompress(const char *in, int len, char *out, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
-  return unishox2_decompress_lines(in, len, out, usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
+int unishox2_decompress(const char *in, int len, char *out, int olen, const byte usx_hcodes[], const byte usx_hcode_lens[], const char *usx_freq_seq[], const char *usx_templates[]) {
+  return unishox2_decompress_lines(in, len, out, olen, usx_hcodes, usx_hcode_lens, usx_freq_seq, usx_templates, NULL);
 }
 
-int unishox2_decompress_simple(const char *in, int len, char *out) {
-  return unishox2_decompress(in, len, out, USX_PSET_DFLT);
+int unishox2_decompress_simple(const char *in, int len, char *out, int olen) {
+  return unishox2_decompress(in, len, out, olen, USX_PSET_DFLT);
 }

--- a/unishox2.c
+++ b/unishox2.c
@@ -423,7 +423,7 @@ int unishox2_compress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(cha
   prev_uni = 0;
   state = USX_ALPHA;
   is_all_upper = 0;
-  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0xFF, UNISHOX_MAGIC_BIT_LEN)); // magic bit
+  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, UNISHOX_MAGIC_BITS, UNISHOX_MAGIC_BIT_LEN)); // magic bit(s)
   for (l=0; l<len; l++) {
 
     if (usx_hcode_lens[USX_DICT] && l < (len - NICE_LEN + 1)) {

--- a/unishox2.c
+++ b/unishox2.c
@@ -718,11 +718,11 @@ int readBit(const char *in, int bit_no) {
    return in[bit_no >> 3] & (0x80 >> (bit_no % 8));
 }
 
-int read8bitCode(const char *in, int len, int *bit_no_p) {
-  int bit_pos = *bit_no_p & 0x07;
-  int char_pos = *bit_no_p >> 3;
+int read8bitCode(const char *in, int len, int bit_no) {
+  int bit_pos = bit_no & 0x07;
+  int char_pos = bit_no >> 3;
   byte code = (((byte)in[char_pos]) << bit_pos);
-  if (((*bit_no_p) + bit_pos) < len) {
+  if (bit_no + bit_pos < len) {
     code |= ((byte)in[++char_pos]) >> (8 - bit_pos);
   } else
     code |= (0xFF >> (8 - bit_pos));
@@ -752,7 +752,7 @@ byte usx_vcode_lookup[36] = {
 
 int readVCodeIdx(const char *in, int len, int *bit_no_p) {
   if (*bit_no_p < len) {
-    byte code = read8bitCode(in, len, bit_no_p);
+    byte code = read8bitCode(in, len, *bit_no_p);
     int i = 0;
     do {
       if (code <= usx_vsections[i]) {
@@ -772,7 +772,7 @@ int readHCodeIdx(const char *in, int len, int *bit_no_p, const byte usx_hcodes[]
   if (!usx_hcode_lens[USX_ALPHA])
     return USX_ALPHA;
   if (*bit_no_p < len) {
-    byte code = read8bitCode(in, len, bit_no_p);
+    byte code = read8bitCode(in, len, *bit_no_p);
     for (int code_pos = 0; code_pos < 5; code_pos++) {
       if ((code & len_masks[usx_hcode_lens[code_pos] - 1]) == usx_hcodes[code_pos]) {
         *bit_no_p += usx_hcode_lens[code_pos];

--- a/unishox2.c
+++ b/unishox2.c
@@ -774,7 +774,7 @@ int readHCodeIdx(const char *in, int len, int *bit_no_p, const byte usx_hcodes[]
   if (*bit_no_p < len) {
     byte code = read8bitCode(in, len, *bit_no_p);
     for (int code_pos = 0; code_pos < 5; code_pos++) {
-      if ((code & len_masks[usx_hcode_lens[code_pos] - 1]) == usx_hcodes[code_pos]) {
+      if (usx_hcode_lens[code_pos] && (code & len_masks[usx_hcode_lens[code_pos] - 1]) == usx_hcodes[code_pos]) {
         *bit_no_p += usx_hcode_lens[code_pos];
         return code_pos;
       }

--- a/unishox2.c
+++ b/unishox2.c
@@ -376,7 +376,7 @@ int append_nibble_escape(char *out, int ol, byte state, const byte usx_hcodes[],
   return ol;
 }
 
-int min_of(char c, int i) {
+long min_of(long c, long i) {
   return c > i ? i : c;
 }
 
@@ -798,23 +798,22 @@ int getStepCodeIdx(const char *in, int len, int *bit_no_p, int limit) {
   return idx;
 }
 
-// TODO: Check length
 int32_t getNumFromBits(const char *in, int len, int bit_no, int count) {
    int32_t ret = 0;
    while (count-- && bit_no < len) {
      ret += (readBit(in, bit_no) ? 1 << count : 0);
      bit_no++;
    }
-   return ret;
+   return count < 0 ? ret : -1;
 }
 
-int readCount(const char *in, int *bit_no_p, int len) {
+int32_t readCount(const char *in, int *bit_no_p, int len) {
   int idx = getStepCodeIdx(in, len, bit_no_p, 4);
   if (idx == 99)
     return -1;
   if (*bit_no_p + count_bit_lens[idx] - 1 >= len)
     return -1;
-  int count = getNumFromBits(in, len, *bit_no_p, count_bit_lens[idx]) + (idx ? count_adder[idx - 1] : 0);
+  int32_t count = getNumFromBits(in, len, *bit_no_p, count_bit_lens[idx]) + (idx ? count_adder[idx - 1] : 0);
   (*bit_no_p) += count_bit_lens[idx];
   return count;
 }
@@ -860,13 +859,13 @@ void writeUTF8(char *out, int *ol, int uni) {
 
 int decodeRepeat(const char *in, int len, char *out, int ol, int *bit_no, struct us_lnk_lst *prev_lines) {
   if (prev_lines) {
-    int dict_len = readCount(in, bit_no, len) + NICE_LEN;
-    if (dict_len < 0)
+    int32_t dict_len = readCount(in, bit_no, len) + NICE_LEN;
+    if (dict_len < NICE_LEN)
       return ol;
-    int dist = readCount(in, bit_no, len);
+    int32_t dist = readCount(in, bit_no, len);
     if (dist < 0)
       return ol;
-    int ctx = readCount(in, bit_no, len);
+    int32_t ctx = readCount(in, bit_no, len);
     if (ctx < 0)
       return ol;
     struct us_lnk_lst *cur_line = prev_lines;
@@ -875,20 +874,20 @@ int decodeRepeat(const char *in, int len, char *out, int ol, int *bit_no, struct
     memmove(out + ol, cur_line->data + dist, dict_len);
     ol += dict_len;
   } else {
-    int dict_len = readCount(in, bit_no, len) + NICE_LEN;
-    if (dict_len < 0)
+    int32_t dict_len = readCount(in, bit_no, len) + NICE_LEN;
+    if (dict_len < NICE_LEN)
       return ol;
-    int dist = readCount(in, bit_no, len) + NICE_LEN - 1;
-    if (dist < 0)
+    int32_t dist = readCount(in, bit_no, len) + NICE_LEN - 1;
+    if (dist < NICE_LEN - 1)
       return ol;
     //printf("Decode len: %d, dist: %d\n", dict_len - NICE_LEN, dist - NICE_LEN + 1);
-    memcpy(out + ol, out + ol - dist, dict_len);
+    memmove(out + ol, out + ol - dist, dict_len);
     ol += dict_len;
   }
   return ol;
 }
 
-char getHexChar(int nibble, int hex_type) {
+char getHexChar(int32_t nibble, int hex_type) {
   if (nibble >= 0 && nibble <= 9)
     return '0' + nibble;
   else if (hex_type < USX_NIB_HEX_UPPER)
@@ -912,7 +911,6 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
   int prev_uni = 0;
 
   len <<= 3;
-  out[ol] = 0;
   while (bit_no < len) {
     int orig_bit_no = bit_no;
     if (dstate == USX_DELTA || h == USX_DELTA) {
@@ -1027,45 +1025,63 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
           int idx = getStepCodeIdx(in, len, &bit_no, 5);
           if (idx == 0) {
             idx = getStepCodeIdx(in, len, &bit_no, 4);
-            int rem = readCount(in, &bit_no, len);
+            int32_t rem = readCount(in, &bit_no, len);
             if (rem < 0)
               break;
             rem = (int)strlen(usx_templates[idx]) - rem;
+            int eof = 0;
             for (int j = 0; j < rem; j++) {
               char c_t = usx_templates[idx][j];
               if (c_t == 'f' || c_t == 'r' || c_t == 't' || c_t == 'o' || c_t == 'F') {
                   char nibble_len = (c_t == 'f' || c_t == 'F' ? 4 : (c_t == 'r' ? 3 : (c_t == 't' ? 2 : 1)));
-                  out[ol++] = getHexChar(getNumFromBits(in, len, bit_no, nibble_len),
+                  const int32_t raw_char = getNumFromBits(in, len, bit_no, nibble_len);
+                  if (raw_char < 0) {
+                      eof = 1;
+                      break;
+                  }
+                  out[ol++] = getHexChar((char)raw_char,
                       c_t == 'f' ? USX_NIB_HEX_LOWER : USX_NIB_HEX_UPPER);
                   bit_no += nibble_len;
               } else
                 out[ol++] = c_t;
             }
+            if (eof) break; // reach input eof
           } else
           if (idx == 5) {
-            int bin_count = readCount(in, &bit_no, len);
+            int32_t bin_count = readCount(in, &bit_no, len);
             if (bin_count < 0)
               break;
+            if (bin_count == 0) // invalid encoding
+              break;
             do {
-              out[ol++] = getNumFromBits(in, len, bit_no, 8);
+              const int32_t raw_char = getNumFromBits(in, len, bit_no, 8);
+              if (raw_char < 0)
+                  break;
+              out[ol++] = (char)raw_char;
               bit_no += 8;
             } while (--bin_count);
+            if (bin_count > 0) break; // reach input eof
           } else {
-            int nibble_count = 0;
+            int32_t nibble_count = 0;
             if (idx == 2 || idx == 4)
               nibble_count = 32;
             else {
               nibble_count = readCount(in, &bit_no, len);
               if (nibble_count < 0)
                 break;
+              if (nibble_count == 0) // invalid encoding
+                break;
             }
             do {
-              int nibble = (int) getNumFromBits(in, len, bit_no, 4);
+              int32_t nibble = getNumFromBits(in, len, bit_no, 4);
+              if (nibble < 0)
+                  break;
               out[ol++] = getHexChar(nibble, idx < 3 ? USX_NIB_HEX_LOWER : USX_NIB_HEX_UPPER);
               if ((idx == 2 || idx == 4) && (nibble_count == 25 || nibble_count == 21 || nibble_count == 17 || nibble_count == 13))
                 out[ol++] = '-';
               bit_no += 4;
             } while (--nibble_count);
+            if (nibble_count > 0) break; // reach input eof
           }
           if (dstate == USX_DELTA)
             h = USX_DELTA;
@@ -1091,10 +1107,12 @@ int unishox2_decompress_lines(const char *in, int len, char *out, const byte usx
           out[ol++] = '\r';
           out[ol++] = '\n';
         } else if (h == USX_NUM && v == 26) {
-          int count = readCount(in, &bit_no, len);
+          int32_t count = readCount(in, &bit_no, len);
           if (count < 0)
             break;
           count += 4;
+          if (ol <= 0)
+            return 0; // invalid encoding
           char rpt_c = out[ol - 1];
           while (count--)
             out[ol++] = rpt_c;

--- a/unishox2.c
+++ b/unishox2.c
@@ -423,7 +423,7 @@ int unishox2_compress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(cha
   prev_uni = 0;
   state = USX_ALPHA;
   is_all_upper = 0;
-  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0x80, 1)); // magic bit
+  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0xFF, UNISHOX_MAGIC_BIT_LEN)); // magic bit
   for (l=0; l<len; l++) {
 
     if (usx_hcode_lens[USX_DICT] && l < (len - NICE_LEN + 1)) {
@@ -952,7 +952,7 @@ int unishox2_decompress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(c
 
   init_coder();
   int ol = 0;
-  bit_no = 1; // ignore the magic bit
+  bit_no = UNISHOX_MAGIC_BIT_LEN; // ignore the magic bit
   dstate = h = USX_ALPHA;
   is_all_upper = 0;
 

--- a/unishox2.h
+++ b/unishox2.h
@@ -28,6 +28,10 @@
 #  define UNISHOX_API_WITH_OUTPUT_LEN 0
 #endif
 
+#ifndef UNISHOX_MAGIC_BITS
+#  define UNISHOX_MAGIC_BITS 0xFF
+#endif
+
 #ifdef UNISHOX_MAGIC_BIT_LEN
 #  if UNISHOX_MAGIC_BIT_LEN < 0 || 8 <= UNISHOX_MAGIC_BIT_LEN
 #    error "UNISHOX_MAGIC_BIT_LEN need between [0, 7)"

--- a/unishox2.h
+++ b/unishox2.h
@@ -21,6 +21,13 @@
 
 #define UNISHOX_VERSION "2.0"
 
+// macro switch to enable/disable output buffer lenth parameter in low level api
+// default disable the output buffer length parameter
+// simple api, i.e. unishox2_(de)compress_simple will always omit the buffer length
+#ifndef UNISHOX_API_WITH_OUTPUT_LEN
+#  define UNISHOX_API_WITH_OUTPUT_LEN 0
+#endif
+
 //enum {USX_ALPHA = 0, USX_SYM, USX_NUM, USX_DICT, USX_DELTA};
 
 #define USX_HCODES_DFLT (const unsigned char[]){0x00, 0x40, 0x80, 0xC0, 0xE0}
@@ -88,19 +95,25 @@ struct us_lnk_lst {
   struct us_lnk_lst *previous;
 };
 
-extern int unishox2_compress_simple(const char *in, int len, char *out, int olen);
-extern int unishox2_decompress_simple(const char *in, int len, char *out, int olen);
-extern int unishox2_compress(const char *in, int len, char *out, int olen,
+#if defined(UNISHOX_API_WITH_OUTPUT_LEN) && UNISHOX_API_WITH_OUTPUT_LEN != 0
+#  define UNISHOX_API_OUT_AND_LEN(out, olen) out, olen
+#else
+#  define UNISHOX_API_OUT_AND_LEN(out, olen) out
+#endif
+
+extern int unishox2_compress_simple(const char *in, int len, char *out);
+extern int unishox2_decompress_simple(const char *in, int len, char *out);
+extern int unishox2_compress(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen),
               const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
               const char *usx_freq_seq[], const char *usx_templates[]);
-extern int unishox2_decompress(const char *in, int len, char *out, int olen,
+extern int unishox2_decompress(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen),
               const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
               const char *usx_freq_seq[], const char *usx_templates[]);
-extern int unishox2_compress_lines(const char *in, int len, char *out, int olen,
+extern int unishox2_compress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen),
               const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
               const char *usx_freq_seq[], const char *usx_templates[],
               struct us_lnk_lst *prev_lines);
-extern int unishox2_decompress_lines(const char *in, int len, char *out, int olen,
+extern int unishox2_decompress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(char *out, int olen),
               const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
               const char *usx_freq_seq[], const char *usx_templates[],
               struct us_lnk_lst *prev_lines);

--- a/unishox2.h
+++ b/unishox2.h
@@ -28,6 +28,14 @@
 #  define UNISHOX_API_WITH_OUTPUT_LEN 0
 #endif
 
+#ifdef UNISHOX_MAGIC_BIT_LEN
+#  if UNISHOX_MAGIC_BIT_LEN < 0 || 8 <= UNISHOX_MAGIC_BIT_LEN
+#    error "UNISHOX_MAGIC_BIT_LEN need between [0, 7)"
+#  endif
+#else
+#  define UNISHOX_MAGIC_BIT_LEN 1
+#endif
+
 //enum {USX_ALPHA = 0, USX_SYM, USX_NUM, USX_DICT, USX_DELTA};
 
 #define USX_HCODES_DFLT (const unsigned char[]){0x00, 0x40, 0x80, 0xC0, 0xE0}

--- a/unishox2.h
+++ b/unishox2.h
@@ -88,19 +88,19 @@ struct us_lnk_lst {
   struct us_lnk_lst *previous;
 };
 
-extern int unishox2_compress_simple(const char *in, int len, char *out);
-extern int unishox2_decompress_simple(const char *in, int len, char *out);
-extern int unishox2_compress(const char *in, int len, char *out, 
-              const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[], 
-              const char *usx_freq_seq[], const char *usx_templates[]);
-extern int unishox2_decompress(const char *in, int len, char *out, 
+extern int unishox2_compress_simple(const char *in, int len, char *out, int olen);
+extern int unishox2_decompress_simple(const char *in, int len, char *out, int olen);
+extern int unishox2_compress(const char *in, int len, char *out, int olen,
               const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
               const char *usx_freq_seq[], const char *usx_templates[]);
-extern int unishox2_compress_lines(const char *in, int len, char *out, 
-              const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[], 
+extern int unishox2_decompress(const char *in, int len, char *out, int olen,
+              const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
+              const char *usx_freq_seq[], const char *usx_templates[]);
+extern int unishox2_compress_lines(const char *in, int len, char *out, int olen,
+              const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
               const char *usx_freq_seq[], const char *usx_templates[],
               struct us_lnk_lst *prev_lines);
-extern int unishox2_decompress_lines(const char *in, int len, char *out, 
+extern int unishox2_decompress_lines(const char *in, int len, char *out, int olen,
               const unsigned char usx_hcodes[], const unsigned char usx_hcode_lens[],
               const char *usx_freq_seq[], const char *usx_templates[],
               struct us_lnk_lst *prev_lines);


### PR DESCRIPTION
Hi @gzm55 Please see my PR for implementing term codes another way.
My problem is that people who want full termination codes is very less because usually the length of compressed bytes is available.
So in this case I pass `olen` as negative to indicate I want full terminator codes.  If it is negative I set `need_full_term_codes` to 1 and pass it to `append_final_bits`, which will append either full terminator codes or just the remaining bits in the last bytes.
This way it is much simpler and also achieve what you have mentioned (here)[https://github.com/siara-cc/Unishox/pull/20/files/c30a384723ccca845a2ab18dfba9da4c359dde29..4f6a4b17b9e310f7d3049a44fb170e0cce563208#r716029637].
Unit test on full term codes can be done by passing `olen` as negative.
We can also improve this in two ways:
- pass `need_full_term_codes` separately after olen
- return the length of terminator codes in `ret` as last two bits and the actual length of compressed bytes in remaining msb bits
This code is just for demo and I have not tested it.