### PR TITLE
Term codes

### DIFF
--- a/unishox2.c
+++ b/unishox2.c
@@ -423,7 +423,7 @@ int unishox2_compress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(cha
   prev_uni = 0;
   state = USX_ALPHA;
   is_all_upper = 0;
-  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0xFF, UNISHOX_MAGIC_BIT_LEN)); // magic bit
+  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, UNISHOX_MAGIC_BITS, UNISHOX_MAGIC_BIT_LEN)); // magic bit(s)
   for (l=0; l<len; l++) {
 
     if (usx_hcode_lens[USX_DICT] && l < (len - NICE_LEN + 1)) {

--- a/unishox2.c
+++ b/unishox2.c
@@ -423,7 +423,7 @@ int unishox2_compress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(cha
   prev_uni = 0;
   state = USX_ALPHA;
   is_all_upper = 0;
-  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0x80, 1)); // magic bit
+  SAFE_APPEND_BITS2(olen, ol = append_bits(out, olen, ol, 0xFF, UNISHOX_MAGIC_BIT_LEN)); // magic bit
   for (l=0; l<len; l++) {
 
     if (usx_hcode_lens[USX_DICT] && l < (len - NICE_LEN + 1)) {
@@ -952,7 +952,7 @@ int unishox2_decompress_lines(const char *in, int len, UNISHOX_API_OUT_AND_LEN(c
 
   init_coder();
   int ol = 0;
-  bit_no = 1; // ignore the magic bit
+  bit_no = UNISHOX_MAGIC_BIT_LEN; // ignore the magic bit
   dstate = h = USX_ALPHA;
   is_all_upper = 0;
 

--- a/unishox2.h
+++ b/unishox2.h
@@ -28,6 +28,10 @@
 #  define UNISHOX_API_WITH_OUTPUT_LEN 0
 #endif
 
+#ifndef UNISHOX_MAGIC_BITS
+#  define UNISHOX_MAGIC_BITS 0xFF
+#endif
+
 #ifdef UNISHOX_MAGIC_BIT_LEN
 #  if UNISHOX_MAGIC_BIT_LEN < 0 || 8 <= UNISHOX_MAGIC_BIT_LEN
 #    error "UNISHOX_MAGIC_BIT_LEN need between [0, 7)"

--- a/unishox2.h
+++ b/unishox2.h
@@ -28,6 +28,14 @@
 #  define UNISHOX_API_WITH_OUTPUT_LEN 0
 #endif
 
+#ifdef UNISHOX_MAGIC_BIT_LEN
+#  if UNISHOX_MAGIC_BIT_LEN < 0 || 8 <= UNISHOX_MAGIC_BIT_LEN
+#    error "UNISHOX_MAGIC_BIT_LEN need between [0, 7)"
+#  endif
+#else
+#  define UNISHOX_MAGIC_BIT_LEN 1
+#endif
+
 //enum {USX_ALPHA = 0, USX_SYM, USX_NUM, USX_DICT, USX_DELTA};
 
 #define USX_HCODES_DFLT (const unsigned char[]){0x00, 0x40, 0x80, 0xC0, 0xE0}


### PR DESCRIPTION
Hi @gzm55 Please see my PR for implementing term codes another way.
My problem is that people who want full termination codes is very less because usually the length of compressed bytes is available.
So in this case I pass `olen` as negative to indicate I want full terminator codes.  If it is negative I set `need_full_term_codes` to 1 and pass it to `append_final_bits`, which will append either full terminator codes or just the remaining bits in the last bytes.
This way it is much simpler and also achieve what you have mentioned (here)[https://github.com/siara-cc/Unishox/pull/20/files/c30a384723ccca845a2ab18dfba9da4c359dde29..4f6a4b17b9e310f7d3049a44fb170e0cce563208#r716029637].
Unit test on full term codes can be done by passing `olen` as negative.
We can also improve this in two ways:
- pass `need_full_term_codes` separately after olen
- return the length of terminator codes in `ret` as last two bits and the actual length of compressed bytes in remaining msb bits
This code is just for demo and I have not tested it.